### PR TITLE
Added support for domain-based logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,17 @@ to login to that wiki.
 
 ```php
 include 'globals.php';
-	
+
 $api_url = 'http://example.com/api.php';
 $username = 'bot';
 $password = 'password';
-	
+
 try
 {
 	$wiki = new Wikimate($api_url);
+
+    // You can pass the domain name either
+    // $wiki->login($username,$password, $domainName)
 	if ($wiki->login($username,$password))
 		echo 'Success: user logged in.' ;
 	else {
@@ -204,16 +207,16 @@ $data = array(
 	'intoken' => 'edit',
 	'titles' => 'this|that|other'
 );
-	
+
 // Send data as a query
 $array_result = $wiki->query( $data );
-	
+
 $data = array(
 	'title' => 'this',
 	'token' => '+\', // this is urlencoded automatically
 	'etc' => 'stuff'
 );
-	
+
 // Send as an edit query with content-type of application/x-www-form-urlencoded
 $array_result = $wiki->edit( $data );
 ```

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -53,7 +53,7 @@ class Wikimate {
 	 * Logs in to the wiki
 	 * @return boolean true if logged in
 	 */
-	public function login( $username, $password ) {
+	public function login( $username, $password, $domain = NULL ) {
 		//Logger::log("Logging in");
 		
 		$details = array(
@@ -62,6 +62,13 @@ class Wikimate {
 			'lgpassword' => $password,
 			'format' => 'json'
 		);
+
+		// If $domain is informed, sets the correspondant detail in the request information array
+		if( $domain )
+		{
+			$details['lgdomain'] = $domain;
+
+		}
 		
 		// Send the login request
 		$response = $this->session->post($this->api, array(), $details);


### PR DESCRIPTION
I really loved this API and I'm using it in a project here in my company that requires this type of configurations...

I does not impact in "non-domain-based" logins.

I added some code into Wikimate's login method and change the README file, adding info about how to inform and where to inform the domain name. 