### PR TITLE
Improvements to section processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ Both methods return an array of the MediaWiki API result.
 
 ## Changelog
 
+### Version 0.11.0
+
+* Improved section processing in getText
+
 ### Version 0.10.1
 
 * Supports optional domain at authentication

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -471,9 +471,9 @@ class WikiPage {
 				$currIndex = 0;
 				$currName  = 'intro';
 				
-				foreach ( $sections as $i => $section ) {
+				foreach ( $sections as $section ) {
 					// Get the current offset
-					$currOffset = strpos( $this->text, $section );
+					$currOffset = strpos( $this->text, $section, $this->sections->byIndex[$currIndex]['offset'] );
 					
 					// Are we still on the first section?
 					if ( $currIndex == 0 ) {
@@ -485,13 +485,22 @@ class WikiPage {
 					$currName = trim( str_replace( '=', '', $section ) );
 					$currIndex++;
 					
+					// Search for existing name and create unique one
+					$cName = $currName;
+					for ($seq = 2; array_key_exists($cName, $this->sections->byName); $seq++) {
+						$cName = $currName . '_' . $seq;
+					}
+					if ($seq > 2) {
+						$currName = $cName;
+					}
+
 					// Set the offset for the current section
 					$this->sections->byIndex[$currIndex]['offset'] = $currOffset;
 					$this->sections->byName[$currName]['offset']   = $currOffset;
 					
 					// If there is a section after this, set the length of this one
 					if ( isset( $sections[$currIndex] ) ) {
-						$nextOffset = strpos( $this->text, $sections[$currIndex] ); // Get the offset of the next section
+						$nextOffset = strpos( $this->text, $sections[$currIndex], $currOffset ); // Get the offset of the next section
 						$length     = $nextOffset - $currOffset; // Calculate the length of this one
 						
 						// Set the length of this section

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -2,7 +2,7 @@
 /// =============================================================================
 /// Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
 /// 
-/// @version    0.10.1
+/// @version    0.11.0
 /// @copyright  SPDX-License-Identifier: MIT
 /// =============================================================================
 
@@ -20,7 +20,7 @@ class Wikimate {
 	/**
 	 * @var  string  The current version number (conforms to http://semver.org/).
 	 */
-	const VERSION = '0.10.1';
+	const VERSION = '0.11.0';
 
 	protected $api;
 	protected $username;
@@ -420,7 +420,7 @@ class WikiPage {
 	 * @return  string             The text of the page
 	 */
 	function getText( $refresh = false ) {
-		if ( $refresh ) { // We want to query the api
+		if ( $refresh ) { // We want to query the API
 			
 			$data = array(
 				'prop' => 'info|revisions',
@@ -438,7 +438,8 @@ class WikiPage {
 				$this->error = null; // Reset the error status
 			}
 			
-			$page = array_pop( $r['query']['pages'] ); // Get the page (there should only be one)
+			// Get the page (there should only be one)
+			$page = array_pop( $r['query']['pages'] );
 			
 			unset( $r, $data );
 			
@@ -450,8 +451,10 @@ class WikiPage {
 			$this->starttimestamp = $page['starttimestamp'];
 			
 			if ( !isset( $page['missing'] ) ) {
-				$this->exists = true; // Update the existance if the page is there
-				$this->text   = $page['revisions'][0]['*']; // Put the content into text
+				// Update the existance if the page is there
+				$this->exists = true;
+				// Put the content into text
+				$this->text   = $page['revisions'][0]['*'];
 			}
 			
 			unset( $page );
@@ -500,8 +503,10 @@ class WikiPage {
 					
 					// If there is a section after this, set the length of this one
 					if ( isset( $sections[$currIndex] ) ) {
-						$nextOffset = strpos( $this->text, $sections[$currIndex], $currOffset ); // Get the offset of the next section
-						$length     = $nextOffset - $currOffset; // Calculate the length of this one
+						// Get the offset of the next section
+						$nextOffset = strpos( $this->text, $sections[$currIndex], $currOffset );
+						// Calculate the length of this one
+						$length     = $nextOffset - $currOffset;
 						
 						// Set the length of this section
 						$this->sections->byIndex[$currIndex]['length'] = $length;

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -457,7 +457,7 @@ class WikiPage {
 			unset( $page );
 			
 			// Now we need to get the section information
-			preg_match_all( '/={1,6}.*={1,6}\n/', $this->text, $m ); // TODO: improve regexp if possible
+			preg_match_all( '/(={1,6}).*?\1 *\n/', $this->text, $m );
 			
 			// Set the intro section (between title and first section)
 			$this->sections->byIndex[0]['offset']      = 0;

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -498,6 +498,11 @@ class WikiPage {
 						$this->sections->byIndex[$currIndex]['length'] = $length;
 						$this->sections->byName[$currName]['length']   = $length;
 					}
+					else {
+						// Set the length of last section
+						$this->sections->byIndex[$currIndex]['length'] = strlen($this->text) - $currOffset;
+						$this->sections->byName[$currName]['length']   = strlen($this->text) - $currOffset;
+					}
 				}
 			}
 		}
@@ -524,15 +529,12 @@ class WikiPage {
 		
 		// Extract the text
 		@extract( $coords );
-		if ( isset( $length ) ) {
-			$text = substr( $this->text, $offset, $length );
-		} else {
-			$text = substr( $this->text, $offset );
-		}
+		$text = substr( $this->text, $offset, $length );
 		
 		// Whack off the heading if need be
 		if ( !$includeHeading && $offset > 0 ) {
-			$text = substr( $text, strpos( trim( $text ), "\n" ) ); // Chop off the first line
+			// Chop off the first line
+			$text = substr( $text, strpos( trim( $text ), "\n" ) );
 		}
 		
 		return $text;


### PR DESCRIPTION
See #31 item 1. Rationale for this change:
Allowing optional trailing spaces is needed, or a section header can be inadvertently skipped. Optional leading spaces don't matter as the pattern isn't anchored there.
Using a back-reference to the first set of ='s insures a symmetric number of them is matched, just like the Wiki engine does.
A minimizer `?` to the inner `.*` makes sense in this situation.

After making these changes I thought to look in the API source, and found in [this file](https://phabricator.wikimedia.org/diffusion/MW/browse/master/includes/EditPage.php) at line 2086 a nearly identical regex:
`$hasmatch = preg_match( "/^ *([=]{1,6})(.*?)(\\1) *\\n/i", ...);`
So I think we're good now and the TODO can be removed.