### PR TITLE
Test for unknown section (fixes #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 ## Changelog
 
+### Version 0.11.1
+
+* Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()`
+
 ### Version 0.11.0
 
-* Improved section processing in getText
+* Improved section processing in `WikiPage::getText()`
 
 ### Version 0.10.1
 
 * Supports optional domain at authentication
-* Bug fix: pass return value in setSection
-* Bug fix: correct call to debugRequestsConfig
+* Bug fix: pass return value in `WikiPage::setSection()`
+* Bug fix: correct call to `Wikimate::debugRequestsConfig()`
 
 ### Version 0.10.0
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -531,13 +531,22 @@ class WikiPage {
 	 *
 	 * @param   mixed    $section         The section to get
 	 * @param   boolean  $includeHeading  False to get section text only
-	 * @return  string                    Wikitext of the section on the page
+	 * @return  string                    Wikitext of the section on the page,
+	 *                                    or false if section is undefined
 	 */
 	function getSection( $section, $includeHeading = false ) {
 		// Check if we have a section name or index
 		if ( is_int( $section ) ) {
+			if ( !isset( $this->sections->byIndex[$section] ) )
+			{
+				return false;
+			}
 			$coords = $this->sections->byIndex[$section];
 		} else if ( is_string( $section ) ) {
+			if ( !isset( $this->sections->byName[$section] ) )
+			{
+				return false;
+			}
 			$coords = $this->sections->byName[$section];
 		}
 		

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -2,7 +2,7 @@
 /// =============================================================================
 /// Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
 /// 
-/// @version    0.11.0
+/// @version    0.11.1
 /// @copyright  SPDX-License-Identifier: MIT
 /// =============================================================================
 
@@ -20,7 +20,7 @@ class Wikimate {
 	/**
 	 * @var  string  The current version number (conforms to http://semver.org/).
 	 */
-	const VERSION = '0.11.0';
+	const VERSION = '0.11.1';
 
 	protected $api;
 	protected $username;


### PR DESCRIPTION
Hmm, I accidentally branched 39-fix-notices off my other branch instead of master. @waldyrious can you delete it and the PR? Sorry for the inconvenience.

In the 39-fix-unknown-section branch the tests return `false` for unknown sections, a common practice in many built-in PHP functions, and the user can test for that using `===`.