### PR TITLE
Collect changes since last release under current version (fixes #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 ### Version 0.12.0
 
-* Supports a section name (in addition to an index) in `WikiPage::setText()` and `WikiPage::setSection()`
-* Improved section processing in `WikiPage::getText()`
-* Supports optional domain at authentication
-* Bug fix: prevent PHP Notices in several methods
-* Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()`
-* Bug fix: pass return value in `WikiPage::setSection()`
-* Bug fix: correct call to `Wikimate::debugRequestsConfig()`
+* Supports a section name (in addition to an index) in `WikiPage::setText()` and `WikiPage::setSection()` (#45)
+* Improved section processing in `WikiPage::getText()` (#33, #35)
+* Supports optional domain at authentication (#28)
+* Restructured and improved documentation (#32, #34, #47)
+* Bug fix: prevent PHP Notices in several methods (#43)
+* Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()` (#41)
+* Bug fix: pass return value in `WikiPage::setSection()` (#30)
+* Bug fix: correct call to `Wikimate::debugRequestsConfig()` (#30)
 
 ### Version 0.10.0
 
-* Switched to using the *Requests* library instead of Curl
+* Switched to using the *Requests* library instead of Curl (#25)
 
 ### Version 0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
 ## Changelog
 
-### Version 0.12.0
+### Version 0.11.0
 
-* Supports a section name (in addition to an index) in `WikiPage::setText()` and `WikiPage::setSection()` (#45)
-* Improved section processing in `WikiPage::getText()` (#33, #35)
-* Supports optional domain at authentication (#28)
-* Restructured and improved documentation (#32, #34, #47)
-* Bug fix: prevent PHP Notices in several methods (#43)
-* Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()` (#41)
-* Bug fix: pass return value in `WikiPage::setSection()` (#30)
-* Bug fix: correct call to `Wikimate::debugRequestsConfig()` (#30)
+* Supports a section name (in addition to an index) in `WikiPage::setText()` and `WikiPage::setSection()` ([#45])
+* Improved section processing in `WikiPage::getText()` ([#33], [#37], [#50])
+* Supports optional domain at authentication ([#28])
+* Restructured and improved documentation ([#32], [#34], [#47], [#49])
+* Bug fix: prevent PHP Notices in several methods ([#43])
+* Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()` ([#41])
+* Bug fix: pass return value in `WikiPage::setSection()` ([#30])
+* Bug fix: correct call to `Wikimate::debugRequestsConfig()` ([#30])
 
 ### Version 0.10.0
 
-* Switched to using the *Requests* library instead of Curl (#25)
+* Switched to using the *Requests* library instead of Curl ([#25])
 
 ### Version 0.5
 
@@ -33,3 +33,18 @@
 ### Version 0.3
 
 * Initial commit
+
+[#25]: https://github.com/hamstar/Wikimate/pull/25
+[#28]: https://github.com/hamstar/Wikimate/pull/28
+[#30]: https://github.com/hamstar/Wikimate/pull/30
+[#32]: https://github.com/hamstar/Wikimate/pull/32
+[#33]: https://github.com/hamstar/Wikimate/pull/33
+[#34]: https://github.com/hamstar/Wikimate/pull/34
+[#37]: https://github.com/hamstar/Wikimate/pull/37
+[#41]: https://github.com/hamstar/Wikimate/pull/41
+[#43]: https://github.com/hamstar/Wikimate/pull/43
+[#45]: https://github.com/hamstar/Wikimate/pull/45
+[#47]: https://github.com/hamstar/Wikimate/pull/47
+[#49]: https://github.com/hamstar/Wikimate/pull/49
+[#50]: https://github.com/hamstar/Wikimate/pull/50
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,10 @@
 ### Version 0.12.0
 
 * Supports a section name (in addition to an index) in `WikiPage::setText()` and `WikiPage::setSection()`
-* Bug fix: prevent PHP Notices in several methods
-
-### Version 0.11.1
-
-* Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()`
-
-### Version 0.11.0
-
 * Improved section processing in `WikiPage::getText()`
-
-### Version 0.10.1
-
 * Supports optional domain at authentication
+* Bug fix: prevent PHP Notices in several methods
+* Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()`
 * Bug fix: pass return value in `WikiPage::setSection()`
 * Bug fix: correct call to `Wikimate::debugRequestsConfig()`
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -2,7 +2,7 @@
 /// =============================================================================
 /// Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
 ///
-/// @version    0.12.0
+/// @version    0.11.0
 /// @copyright  SPDX-License-Identifier: MIT
 /// =============================================================================
 
@@ -17,7 +17,7 @@ class Wikimate
 	/**
 	 * @var  string  The current version number (conforms to http://semver.org/).
 	 */
-	const VERSION = '0.12.0';
+	const VERSION = '0.11.0';
 
 	protected $api;
 	protected $username;


### PR DESCRIPTION
Kept v0.12.0 (in Wikimate.php too) as it would be confusing to go back now.

@waldyrious Could you comment on #38?

Btw, to test-render .md files, [this site](https://jbt.github.io/markdown-editor/) is quite useful. :+1: 