### PR TITLE
Improve regex for section header at end of page

### DIFF
--- a/Wikimate.php
+++ b/Wikimate.php
@@ -481,7 +481,7 @@ class WikiPage
 			unset( $page );
 			
 			// Now we need to get the section headers, if any
-			preg_match_all( '/(={1,6}).*?\1 *\n/', $this->text, $matches );
+			preg_match_all( '/(={1,6}).*?\1 *(?:\n|$)/', $this->text, $matches );
 			
 			// Set the intro section (between title and first section)
 			$this->sections->byIndex[0]['offset']      = 0;


### PR DESCRIPTION
I discovered that [this rationale](https://github.com/hamstar/Wikimate/pull/33#issue-180529597) is incomplete: getting the page text will not include a newline after that last line (talk about unexpected...), therefore if a section header is the last line on the page, the regex will fail to match that header.

This commit fixes it, by accepting (but not capturing) a newline _or_ the end of the text.