### PR TITLE
Fix returning empty section w/o header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improved section processing in `WikiPage::getText()` ([#33], [#37], [#50])
 * Supports optional domain at authentication ([#28])
 * Restructured and improved documentation ([#32], [#34], [#47], [#49])
+* Bug fix: return empty section without header in `WikiPage::getSection()` ([#52])
 * Bug fix: prevent PHP Notices in several methods ([#43])
 * Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()` ([#41])
 * Bug fix: pass return value in `WikiPage::setSection()` ([#30])
@@ -47,4 +48,5 @@
 [#47]: https://github.com/hamstar/Wikimate/pull/47
 [#49]: https://github.com/hamstar/Wikimate/pull/49
 [#50]: https://github.com/hamstar/Wikimate/pull/50
+[#52]: https://github.com/hamstar/Wikimate/pull/52
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -585,7 +585,7 @@ class WikiPage
 		// Whack off the heading if need be
 		if ( !$includeHeading && $offset > 0 ) {
 			// Chop off the first line
-			$text = substr( $text, strpos( trim( $text ), "\n" ) );
+			$text = substr( $text, strpos( $text, "\n" ) );
 		}
 		
 		return $text;


### PR DESCRIPTION
See #51. The `trim` on a section without body leaves nothing but the header without trailing newline. Thus `strpos` fails and `substr` returns the original section text including header. The `trim` simply isn't needed to find the first newline, as the `preg_match_all` pattern already insures the section text begins with at least one `=` (so a `ltrim` is not needed either).