### PR TITLE
Modify getSection to optionally include subsections (fixes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ### Version 0.11.0
 
+* `WikiPage::getSection()` now includes subsections by default; disabling the new $includeSubsections option reverts to the old behavior of returning only the text until the first subsection ([#55])
 * Supports a section name (in addition to an index) in `WikiPage::setText()` and `WikiPage::setSection()` ([#45])
-* Improved section processing in `WikiPage::getText()` ([#33], [#37], [#50])
+* Improves section processing in `WikiPage::getText()` ([#33], [#37], [#50])
 * Supports optional domain at authentication ([#28])
-* Restructured and improved documentation ([#32], [#34], [#47], [#49])
+* Restructures and improves documentation ([#32], [#34], [#47], [#49])
 * Bug fix: return empty section without header in `WikiPage::getSection()` ([#52])
 * Bug fix: prevent PHP Notices in several methods ([#43])
 * Bug fix: handle unknown section parameter correctly in `WikiPage::getSection()` ([#41])
@@ -49,4 +50,5 @@
 [#49]: https://github.com/hamstar/Wikimate/pull/49
 [#50]: https://github.com/hamstar/Wikimate/pull/50
 [#52]: https://github.com/hamstar/Wikimate/pull/52
+[#55]: https://github.com/hamstar/Wikimate/pull/55
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -74,12 +74,14 @@ You can get sections from the page as well, via the section index, or the sectio
 $wikiCode = $page->getSection(0);
 // get the part between the title and the first section
 $wikiCode = $page->getSection('intro');
-// get the 4th section on the page
+// get the 4th section on the page and any subsections, but no heading
 $wikiCode = $page->getSection(4);
-// get the section called History
+// get the section called History and any subsections, but no heading
 $wikiCode = $page->getSection('History');
-// get the 4th section on the page including the heading
-$wikiCode = $page->getSection(4, true);
+// get the section called History including the heading, and any subsections
+$wikiCode = $page->getSection('History', true);
+// get the 4th section on the page including the heading, without subsections
+$wikiCode = $page->getSection(4, true, false);
 ```
 
 You can even get an array with all the sections in it by either index or name:

--- a/USAGE.md
+++ b/USAGE.md
@@ -74,10 +74,10 @@ You can get sections from the page as well, via the section index, or the sectio
 $wikiCode = $page->getSection(0);
 // get the part between the title and the first section
 $wikiCode = $page->getSection('intro');
-// get the 4th section on the page and any subsections, but no heading
-$wikiCode = $page->getSection(4);
 // get the section called History and any subsections, but no heading
 $wikiCode = $page->getSection('History');
+// get the 4th section on the page and any subsections, but no heading
+$wikiCode = $page->getSection(4);
 // get the section called History including the heading, and any subsections
 $wikiCode = $page->getSection('History', true);
 // get the 4th section on the page including the heading, without subsections

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -556,17 +556,17 @@ class WikiPage
 	}
 	
 	/**
-	 * Returns the section requested, with its subsections, if any.
+	 * Returns the requested section, with its subsections, if any.
 	 *
 	 * Section can be the following:
 	 * - section name (string:"History")
 	 * - section index (int:3)
 	 *
 	 * @param   mixed    $section             The section to get
-	 * @param   boolean  $includeHeading      False to get section text only, true
-	 *                                        to include heading too
-	 * @param   boolean  $includeSubsections  False to get section text only, true
-	 *                                        to include subsections too
+	 * @param   boolean  $includeHeading      False to get section text only,
+	 *                                        true to include heading too
+	 * @param   boolean  $includeSubsections  False to get section text only,
+	 *                                        true to include subsections too
 	 * @return  string                        Wikitext of the section on the page,
 	 *                                        or false if section is undefined
 	 */

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -508,7 +508,9 @@ class WikiPage
 					// Are we still on the first section?
 					if ( $currIndex == 0 ) {
 						$this->sections->byIndex[$currIndex]['length'] = $currOffset;
+						$this->sections->byIndex[$currIndex]['depth']  = 0;
 						$this->sections->byName[$currName]['length']   = $currOffset;
+						$this->sections->byName[$currName]['depth']    = 0;
 					}
 					
 					// Get the current name and index
@@ -524,9 +526,11 @@ class WikiPage
 						$currName = $cName;
 					}
 
-					// Set the offset for the current section
+					// Set the offset and depth (from the matched ='s) for the current section
 					$this->sections->byIndex[$currIndex]['offset'] = $currOffset;
+					$this->sections->byIndex[$currIndex]['depth']  = strlen( $matches[1][$currIndex-1] );
 					$this->sections->byName[$currName]['offset']   = $currOffset;
+					$this->sections->byName[$currName]['depth']    = strlen( $matches[1][$currIndex-1] );
 					
 					// If there is a section after this, set the length of this one
 					if ( isset( $sections[$currIndex] ) ) {

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -444,10 +444,10 @@ class WikiPage
 		if ( $refresh ) { // We want to query the API
 			
 			$data = array(
-				'prop' => 'info|revisions',
-				'intoken' => 'edit',
 				'titles' => $this->title,
-				'rvprop' => 'content' // Need to get page text
+				'prop' => 'info|revisions',
+				'rvprop' => 'content', // Need to get page text
+				'intoken' => 'edit',
 			);
 			
 			$r = $this->wikimate->query( $data ); // Run the query
@@ -684,7 +684,7 @@ class WikiPage
 			'md5' => md5( $text ),
 			'bot' => "true",
 			'token' => $this->edittoken,
-			'starttimestamp' => $this->starttimestamp
+			'starttimestamp' => $this->starttimestamp,
 		);
 		
 		// Set options from arguments
@@ -722,9 +722,9 @@ class WikiPage
 			
 			// Get the new starttimestamp
 			$data = array(
+				'titles' => $this->title,
 				'prop' => 'info',
 				'intoken' => 'edit',
-				'titles' => $this->title
 			);
 			
 			$r = $this->wikimate->query( $data );
@@ -786,7 +786,7 @@ class WikiPage
 	{
 		$data = array(
 			'title' => $this->title,
-			'token' => $this->edittoken
+			'token' => $this->edittoken,
 		);
 		
 		// Set options from arguments


### PR DESCRIPTION
See #53. Tracking section depth is needed to support old and new behavior of getSection. And a user of `getSectionOffsets` may find another use for it too.

In `getSection` if `includeSubsections` is true, the new `foreach` needs to loop over any sections following the requested one and add their lengths to the initial one. It can use either the `byIndex` or `byName` array, that doesn't matter, and first iterates until the same offset as the requested section, then adds those lengths until an entry is no longer a subsection.

Yes, already had this algorithm roughly in my mind even before creating the issue. :sunglasses: 