### PR TITLE
Handle MediaWiki API and other errors consistently (fixes #59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 * Updated `WikiPage::getSection()` to include subsections by default; disabling the new `$includeSubsections` option reverts to the old behavior of returning only the text until the first subsection ([#55])
 * Improved section processing in `WikiPage::getText()` ([#33], [#37], [#50])
+* Ensured that MediaWiki API error responses appear directly in `WikiPage::$error` rather than a nested 'error' array ([#63]) -- this may require changes in your application's error handling
 * Restructured and improved documentation ([#32], [#34], [#47], [#49], [#61])
 
 #### Fixed
@@ -67,4 +68,5 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#55]: https://github.com/hamstar/Wikimate/pull/55
 [#57]: https://github.com/hamstar/Wikimate/pull/57
 [#61]: https://github.com/hamstar/Wikimate/pull/61
+[#63]: https://github.com/hamstar/Wikimate/pull/63
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,5 +67,4 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#55]: https://github.com/hamstar/Wikimate/pull/55
 [#57]: https://github.com/hamstar/Wikimate/pull/57
 [#61]: https://github.com/hamstar/Wikimate/pull/61
-[#64]: https://github.com/hamstar/Wikimate/pull/64
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -171,8 +171,12 @@ If you pass in a message argument, it will be recorded as a reason for the delet
 Did something go wrong?  Check the error array:
 
 ```php
-print_r( $this->getError() );
+print_r($page->getError());
 ```
+
+For MediaWiki API errors, the array contains the 'code' and 'info' key/value pairs [defined by the API](https://www.mediawiki.org/wiki/API:Errors_and_warnings#Errors).  For other errors, the following key/value pairs are returned:
+* 'login' for Wikimate authentication problems
+* 'page' for WikiPage errors
 
 Wanna run your own queries?
 You can use the edit and query commands in Wikimate:

--- a/USAGE.md
+++ b/USAGE.md
@@ -44,7 +44,7 @@ If the title given to the WikiPage object is invalid, your `$page` object will b
 // create a new page object
 $page = $wiki->getPage('Sausages');
 // check if the page exists or not
-if ( $page->exists() ) die();
+if ($page->exists()) die();
 // get the page title
 echo $page->getTitle();
 // get the number of sections on the page
@@ -130,26 +130,26 @@ You can use both section names and section indexes here.
 
 ```php
 // provide a section number to overwrite only that section
-$page->setText("==Section 4==\n\nThis will appear in section 4", 4 );
+$page->setText("==Section 4==\n\nThis will appear in section 4", 4);
 // ... or overwrite a section by name
-$page->setText("==History==\n\nThis will appear in the history section", 'History' );
+$page->setText("==History==\n\nThis will appear in the history section", 'History');
 // ...or make a new section
-$page->setText("==New section==\n\nStuff", 'new' )
+$page->setText("==New section==\n\nStuff", 'new')
 // ...zero is the very first section
-$page->setText("Sausages are cylindrical packages of meat.", 0 )
+$page->setText("Sausages are cylindrical packages of meat.", 0)
 ```
 
 The minor edit switch and the edit summary description are the third and fourth arguments:
 
 ```php
-$page->setText( $text, $section, true, "removing spam!");
+$page->setText($text, $section, true, "removing spam!");
 ```
 
 Here are some easier methods for editing sections:
 
 ```php
-$page->setSection( $text, $section, $summary, $minor );
-$page->newSection( $sectionTitle, $text );
+$page->setSection($text, $section, $summary, $minor);
+$page->newSection($sectionTitle, $text);
 ```
 
 For the latter method, the $sectionTitle is also used as part of the edit summary description.
@@ -189,7 +189,7 @@ $data = array(
 );
 
 // Send data as a query
-$array_result = $wiki->query( $data );
+$array_result = $wiki->query($data);
 
 $data = array(
 	'title' => 'this',
@@ -198,7 +198,7 @@ $data = array(
 );
 
 // Send as an edit query with content-type of application/x-www-form-urlencoded
-$array_result = $wiki->edit( $data );
+$array_result = $wiki->edit($data);
 ```
 
 Both methods return an array of the MediaWiki API result.

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -80,7 +80,8 @@ class Wikimate
 		$response = $this->session->post($this->api, array(), $details);
 		// Check if we got an API result or the API doc page (invalid request)
 		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
-			$this->error['login'] = "The API could not understand the first login request";
+			$this->error = array();
+			$this->error['login'] = 'The API could not understand the first login request';
 			return false;
 		}
 
@@ -93,7 +94,7 @@ class Wikimate
 			print_r($loginResult);
 		}
 
-		if ($loginResult->login->result == "NeedToken") {
+		if ($loginResult->login->result == 'NeedToken') {
 			//Logger::log("Sending token {$loginResult->login->token}");
 			$details['lgtoken'] = strtolower(trim($loginResult->login->token));
 
@@ -102,7 +103,8 @@ class Wikimate
 
 			// Check if we got an API result or the API doc page (invalid request)
 			if (strpos($loginResult, "This is an auto-generated MediaWiki API documentation page") !== false) {
-				$this->error['login'] = "The API could not understand the confirm token request";
+				$this->error = array();
+				$this->error['login'] = 'The API could not understand the confirm token request';
 				return false;
 			}
 
@@ -115,8 +117,9 @@ class Wikimate
 				print_r($loginResult);
 			}
 
-			if ($loginResult->login->result != "Success") {
+			if ($loginResult->login->result != 'Success') {
 				// Some more comprehensive error checking
+				$this->error = array();
 				switch ($loginResult->login->result) {
 					case 'NotExists':
 						$this->error['login'] = 'The username does not exist';
@@ -718,7 +721,7 @@ class WikiPage
 		$r = $this->wikimate->edit($data); // The edit query
 
 		// Check if it worked
-		if (isset($r['edit']['result']) && $r['edit']['result'] == "Success") {
+		if (isset($r['edit']['result']) && $r['edit']['result'] == 'Success') {
 			$this->exists = true;
 
 			if (is_null($section)) {
@@ -850,7 +853,7 @@ class WikiPage
 
 		// Return error message and value
 		$this->error = array();
-		$this->error['section'] = "The section is not found on this page";
+		$this->error['page'] = 'The section is not found on this page';
 		return -1;
 	}
 }

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -443,7 +443,7 @@ class WikiPage
 	 * then this method will query the wiki API again for the page details.
 	 *
 	 * @param   boolean  $refresh  True to query the wiki API again
-	 * @return  string             The text of the page
+	 * @return  mixed              The text of the page (string), or null if error
 	 */
 	public function getText($refresh = false)
 	{
@@ -459,7 +459,8 @@ class WikiPage
 
 			// Check for errors
 			if (isset($r['error'])) {
-				$this->error = $r; // Set the error if there was one
+				$this->error = $r['error']; // Set the error if there was one
+				return null;
 			} else {
 				$this->error = null; // Reset the error status
 			}
@@ -742,7 +743,13 @@ class WikiPage
 			return true;
 		}
 
-		$this->error = $r; // Return error response
+		// Return error response
+		if (isset($r['error'])) {
+			$this->error = $r['error'];
+		} else {
+			$this->error = array();
+			$this->error['page'] = 'Unexpected edit response: '.$r['edit']['result'];
+		}
 		return false;
 	}
 
@@ -808,7 +815,7 @@ class WikiPage
 			return true;
 		}
 
-		$this->error = $r; // Return error response
+		$this->error = $r['error']; // Return error response
 		return false;
 	}
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -321,8 +321,7 @@ class WikiPage
 		$this->text     = $this->getText(true);
 
 		if ($this->invalid) {
-			$this->error['page'] = "Invalid page title - cannot create WikiPage";
-			return null;
+			$this->error['page'] = 'Invalid page title - cannot create WikiPage';
 		}
 	}
 
@@ -726,7 +725,6 @@ class WikiPage
 
 			if (is_null($section)) {
 				$this->text = $text;
-			} else {
 			}
 
 			// Get the new starttimestamp


### PR DESCRIPTION
See #59. Commit 7fc1c0f ensures that MW API errors in `$r['error']` are copied to `$this->error` in all cases where it may be returned. In `getText`, line 463 also ceases further processing in case of an API error - previously it would still parse the response and attempt to extract sections if the `invalid` flag wasn't set in the response.

The `setText` handling of API responses became a little more complex than I first anticipated. Earlier in the method it checks `$r['edit']['result']` for `Success` but that implies a different result is also possible, instead of an `$r['error']` array. The [MW edit page](https://www.mediawiki.org/wiki/API:Edit#CAPTCHAs_and_extension_errors) describes the alternative, `Failure`. In order to keep WikiPage simple and easy, I didn't handle such situations in detail, the `isset` merely avoids a PHP notice if `$r['error']` is undefined because of the Failure result, and that result is passed in a custom message.

In the `delete` method all this isn't needed (line 818) because there's no `'result'` element with different possible values in the `'delete'` response.