### PR TITLE
Prevent a PHP Notice at login & improve documentation (fixes #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 * Ensured use of Wikimate user agent by Requests library ([#64])
 * Corrected handling an invalid page title ([#57])
 * Fixed returning an empty section without header in `WikiPage::getSection()` ([#52])
-* Prevented PHP Notices in several methods ([#43])
+* Prevented PHP Notices in several methods ([#43], [#67])
 * Corrected handling an unknown section parameter in `WikiPage::getSection()` ([#41])
 * Fixed passing the return value in `WikiPage::setSection()` ([#30])
 * Corrected call to `Wikimate::debugRequestsConfig()` ([#30])
@@ -70,4 +70,5 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#61]: https://github.com/hamstar/Wikimate/pull/61
 [#63]: https://github.com/hamstar/Wikimate/pull/63
 [#64]: https://github.com/hamstar/Wikimate/pull/64
+[#67]: https://github.com/hamstar/Wikimate/pull/67
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -58,9 +58,12 @@ class Wikimate
 	/**
 	 * Logs in to the wiki.
 	 *
-	 * @return  boolean  True if logged in
+	 * @param   string   $username  The user name
+	 * @param   string   $password  The user password
+	 * @param   string   $domain    The domain (optional)
+	 * @return  boolean             True if logged in
 	 */
-	public function login($username, $password, $domain = NULL)
+	public function login($username, $password, $domain = null)
 	{
 		//Logger::log("Logging in");
 
@@ -94,7 +97,7 @@ class Wikimate
 			print_r($loginResult);
 		}
 
-		if ($loginResult->login->result == 'NeedToken') {
+		if (isset($loginResult->login->result) && $loginResult->login->result == 'NeedToken') {
 			//Logger::log("Sending token {$loginResult->login->token}");
 			$details['lgtoken'] = strtolower(trim($loginResult->login->token));
 


### PR DESCRIPTION
See #66: apply the suggested change, although only one `isset` is needed.