### PR TITLE
Add uploadFromUrl and restructure other upload methods (fixes #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 #### Added
 
-* New class WikiFile to retrieve properties of a file, and download and upload its contents.  All properties pertain to the current revision of the file. ([#69])
+* New class WikiFile to retrieve properties of a file, and download and upload its contents.  All properties pertain to the current revision of the file. ([#69], [#71])
 
 ### Version 0.11.0
 
@@ -78,4 +78,5 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#64]: https://github.com/hamstar/Wikimate/pull/64
 [#67]: https://github.com/hamstar/Wikimate/pull/67
 [#69]: https://github.com/hamstar/Wikimate/pull/69
+[#71]: https://github.com/hamstar/Wikimate/pull/71
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -196,31 +196,36 @@ echo $file->getAspectRatio();
 
 ### Downloading...
 
-You can obtain the data of the file by using the `download()` method and use it in your script, or write it directly to a local file via the `downloadFile()` method.
+You can obtain the data of the file by using the `downloadData()` method and use it in your script, or write it directly to a local file via the `downloadFile()` method.
 
 ```php
-$data = $file->download();
+$data = $file->downloadData();
 // process image $data of Site-logo.png
 $result = $file->downloadFile('/path/to/sitelogo.png');
 ```
 
 ### Uploading...
 
-You can upload data from your script to the file by using the `upload()` method, or read it directly from a local file via the `uploadFile()` method.
+You can upload data from your script to the file by using the `uploadData()` method, or read it directly from a local file via the `uploadFile()` method. Additionally, uploading from a URL is possible via the `uploadFromUrl()` method.
 
 A comment for the file's history must be supplied, and for a new file the text for its associated description page can be provided as well. If no such text is passed, the comment will be used instead.
 
-The `upload()` and `uploadFile()` methods guard against uploading data to an existing file, but allow this when the overwrite flag is set.
+All upload methods guard against uploading data to an existing file, but allow this when the overwrite flag is set.
 
 ```php
 // construct image $data for Site-logo.png
-$result = upload($data, 'Upload new site logo', 'New site logo to reflect the new brand', true);
+$result = uploadData($data, 'Upload new site logo', 'New site logo to reflect the new brand', true);
 $result = uploadFile('/path/to/newlogo.png', 'Upload new site logo', 'New site logo to reflect the new brand', true);
 
 // add a new button to the site
 $file = $wiki->getFile('New-button.png');
 if ($file->exists()) die('New button already exists');
 $result = uploadFile('/path/to/newbutton.png', 'Upload new button', 'New button to match the new logo');
+
+// add an example image from a remote URL
+$file = $wiki->getFile('Wiki-example.jpg');
+if ($file->exists()) die('Example image already exists');
+$result = uploadFromUrl('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg', 'Adopt Wiki example image');
 ```
 
 ### Deleting...

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -526,6 +526,7 @@ class WikiPage
 	public function getText($refresh = false)
 	{
 		if ($refresh) { // We want to query the API
+			// Specify relevant page properties to retrieve
 			$data = array(
 				'titles' => $this->title,
 				'prop' => 'info|revisions',
@@ -1053,7 +1054,7 @@ class WikiFile
 	public function getInfo($refresh = false)
 	{
 		if ($refresh) { // We want to query the API
-
+			// Specify all image properties to retrieve
 			$data = array(
 				'titles' => 'File:' . $this->filename,
 				'prop' => 'info|imageinfo',
@@ -1115,7 +1116,7 @@ class WikiFile
 	/**
 	 * Returns the bit depth of this file.
 	 *
-	 * @return  int  The bit depth of this file
+	 * @return  integer  The bit depth of this file
 	 */
 	public function getBitDepth()
 	{
@@ -1175,7 +1176,7 @@ class WikiFile
 	/**
 	 * Returns the height of this file.
 	 *
-	 * @return  int  The height of this file
+	 * @return  integer  The height of this file
 	 */
 	public function getHeight()
 	{
@@ -1235,7 +1236,7 @@ class WikiFile
 	/**
 	 * Returns the size of this file.
 	 *
-	 * @return  int  The size of this file
+	 * @return  integer  The size of this file
 	 */
 	public function getSize()
 	{
@@ -1286,7 +1287,7 @@ class WikiFile
 	/**
 	 * Returns the ID of the user who uploaded this file.
 	 *
-	 * @return  int  The user ID of this file
+	 * @return  integer  The user ID of this file
 	 */
 	public function getUserId()
 	{
@@ -1296,7 +1297,7 @@ class WikiFile
 	/**
 	 * Returns the width of this file.
 	 *
-	 * @return  int  The width of this file
+	 * @return  integer  The width of this file
 	 */
 	public function getWidth()
 	{
@@ -1315,7 +1316,7 @@ class WikiFile
 	 *
 	 * @return  mixed  Contents (string), or null if error
 	 */
-	public function download()
+	public function downloadData()
 	{
 		// Download file, or handle error
 		$data = $this->wikimate->download($this->getUrl());
@@ -1337,7 +1338,7 @@ class WikiFile
 	public function downloadFile($path)
 	{
 		// Download contents of current file
-		if (($data = $this->download()) === null) {
+		if (($data = $this->downloadData()) === null) {
 			return false;
 		}
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -1054,7 +1054,7 @@ class WikiFile
 	public function getInfo($refresh = false)
 	{
 		if ($refresh) { // We want to query the API
-			// Specify all image properties to retrieve
+			// Specify relevant file properties to retrieve
 			$data = array(
 				'titles' => 'File:' . $this->filename,
 				'prop' => 'info|imageinfo',
@@ -1354,8 +1354,8 @@ class WikiFile
 
 	/**
 	 * Uploads to the current file using the given parameters.
-	 * $text is only used for the article page of a new file, not an existing
-	 * (update that via WikiPage::setText()).
+	 * $text is only used for the page contents of a new file,
+	 * not an existing (update that via WikiPage::setText()).
 	 * If no $text is specified, $comment will be used as new page text.
 	 *
 	 * @param   array    $params     The upload parameters
@@ -1405,8 +1405,8 @@ class WikiFile
 
 	/**
 	 * Uploads the given contents to the current file.
-	 * $text is only used for the article page of a new file, not an existing
-	 * (update that via WikiPage::setText()).
+	 * $text is only used for the page contents of a new file,
+	 * not an existing (update that via WikiPage::setText()).
 	 * If no $text is specified, $comment will be used as new page text.
 	 *
 	 * @param   string   $data       The data to upload
@@ -1428,8 +1428,8 @@ class WikiFile
 
 	/**
 	 * Reads contents from the given path and uploads it to the current file.
-	 * $text is only used for the article page of a new file, not an existing
-	 * (update that via WikiPage::setText()).
+	 * $text is only used for the page contents of a new file,
+	 * not an existing (update that via WikiPage::setText()).
 	 * If no $text is specified, $comment will be used as new page text.
 	 *
 	 * @param   string   $path       The file path to upload
@@ -1453,8 +1453,8 @@ class WikiFile
 
 	/**
 	 * Uploads file contents from the given URL to the current file.
-	 * $text is only used for the article page of a new file, not an existing
-	 * (update that via WikiPage::setText()).
+	 * $text is only used for the page contents of a new file,
+	 * not an existing (update that via WikiPage::setText()).
 	 * If no $text is specified, $comment will be used as new page text.
 	 *
 	 * @param   string   $url        The URL from which to upload

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -1352,18 +1352,18 @@ class WikiFile
 	}
 
 	/**
-	 * Uploads the given contents to the current file.
+	 * Uploads to the current file using the given parameters.
 	 * $text is only used for the article page of a new file, not an existing
 	 * (update that via WikiPage::setText()).
 	 * If no $text is specified, $comment will be used as new page text.
 	 *
-	 * @param   string   $data       The data to upload
+	 * @param   array    $params     The upload parameters
 	 * @param   string   $comment    Upload comment for the file
 	 * @param   string   $text       The article text for the file page
 	 * @param   boolean  $overwrite  True to overwrite existing file
 	 * @return  boolean              True if uploading was successful
 	 */
-	public function upload($data, $comment, $text = null, $overwrite = false)
+	private function uploadCommon(array $params, $comment, $text = null, $overwrite = false)
 	{
 		// Check whether to overwrite existing file
 		if ($this->exists && !$overwrite) {
@@ -1373,15 +1373,12 @@ class WikiFile
 		}
 
 		// Collect upload parameters
-		$params = array(
-			'filename' => $this->filename,
-			'comment' => $comment,
-			'ignorewarnings' => $overwrite,
-			'file' => $data,
-			'token' => $this->edittoken,
-		);
-		if ($text !== null) {
-			$params['text'] = $text;
+		$params['filename']       = $this->filename;
+		$params['comment']        = $comment;
+		$params['ignorewarnings'] = $overwrite;
+		$params['token']          = $this->edittoken;
+		if (!is_null($text)) {
+			$params['text']   = $text;
 		}
 
 		// Upload file, or handle error
@@ -1406,6 +1403,29 @@ class WikiFile
 	}
 
 	/**
+	 * Uploads the given contents to the current file.
+	 * $text is only used for the article page of a new file, not an existing
+	 * (update that via WikiPage::setText()).
+	 * If no $text is specified, $comment will be used as new page text.
+	 *
+	 * @param   string   $data       The data to upload
+	 * @param   string   $comment    Upload comment for the file
+	 * @param   string   $text       The article text for the file page
+	 * @param   boolean  $overwrite  True to overwrite existing file
+	 * @return  boolean              True if uploading was successful
+	 */
+	public function uploadData($data, $comment, $text = null, $overwrite = false)
+	{
+		// Collect upload parameter
+		$params = array(
+			'file' => $data,
+		);
+
+		// Upload contents to current file
+		return $this->uploadCommon($params, $comment, $text, $overwrite);
+	}
+
+	/**
 	 * Reads contents from the given path and uploads it to the current file.
 	 * $text is only used for the article page of a new file, not an existing
 	 * (update that via WikiPage::setText()).
@@ -1427,6 +1447,29 @@ class WikiFile
 		}
 
 		// Upload contents to current file
-		return $this->upload($data, $comment, $text, $overwrite);
+		return $this->uploadData($data, $comment, $text, $overwrite);
+	}
+
+	/**
+	 * Uploads file contents from the given URL to the current file.
+	 * $text is only used for the article page of a new file, not an existing
+	 * (update that via WikiPage::setText()).
+	 * If no $text is specified, $comment will be used as new page text.
+	 *
+	 * @param   string   $url        The URL from which to upload
+	 * @param   string   $comment    Upload comment for the file
+	 * @param   string   $text       The article text for the file page
+	 * @param   boolean  $overwrite  True to overwrite existing file
+	 * @return  boolean              True if uploading was successful
+	 */
+	public function uploadFromUrl($url, $comment, $text = null, $overwrite = false)
+	{
+		// Collect upload parameter
+		$params = array(
+			'url' => $url,
+		);
+
+		// Upload URL to current file
+		return $this->uploadCommon($params, $comment, $text, $overwrite);
 	}
 }


### PR DESCRIPTION
See #70. Previously, `upload()` took $data and `uploadFile()` invoked `upload()`. However, `uploadFromUrl()` takes $url and otherwise needs exactly the same code as `upload()`. To allow sharing this common code, I had to restructure `upload()` a bit into a private method, `uploadCommon()` (maybe there's a better name for that?), and then its public use is made clearer by a new name, `uploadData()`.

The previous merge is just a few days old (so hasn't spread far yet) and still falls under "current development", so this API change seems acceptable to me, as it leads to consistent naming of the three public upload methods. For further consistency, I renamed `download()` to `downloadData()` as well.