### PR TITLE
Add getHistory, getRevision, getArchivename, delete methods to WikiFile (fixes #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 #### Added
 
 * New class WikiFile to retrieve properties of a file, and download and upload its contents.  All properties pertain to the current revision of the file. ([#69], [#71])
+* WikiFile also provides the file history and the ability to delete a file or an older revision of it. ([#76])
 
 ### Version 0.11.0
 
@@ -79,4 +80,5 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#67]: https://github.com/hamstar/Wikimate/pull/67
 [#69]: https://github.com/hamstar/Wikimate/pull/69
 [#71]: https://github.com/hamstar/Wikimate/pull/71
+[#76]: https://github.com/hamstar/Wikimate/pull/76
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -228,14 +228,53 @@ if ($file->exists()) die('Example image already exists');
 $result = uploadFromUrl('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg', 'Adopt Wiki example image');
 ```
 
-### Deleting...
+### History...
 
-If the account you're using has delete permissions, you can delete files as well via `delete()` on its description page:
+The revision history of a file can be obtained as an array with a properties array per revision:
 
 ```php
-$page = $wiki->getPage('File:Old-button.png');
+$file = $wiki->getFile('Often-changed-file.zip');
+// get only the current revision
+$history = $file->getHistory();
+// get the maximum number of revisions (500 for user accounts, 5000 for bot accounts)
+$history = $file->getHistory(true);
+// get the latest 10 revisions during 2015 (can use all MediaWiki timestamp formats)
+$history = $file->getHistory(true, 10, '2015-01-01 00:00:00', '2015-12-31 23:59:59');
+// iterate over revisions and print properties
+foreach ($history as $revision => $properties) {
+  echo "Revision $revision properties:\n";
+  print_r($properties);
+}
+```
+
+One specific revision can be requested by revision sequence number or by exact timestamp in the current history, as can its archive name:
+
+```php
+// get the latest 50 revisions
+$history = $file->getHistory(true, 50);
+// get the properties of the penultimate revision
+$revision = $file->getRevision(1);
+// get the archive name of the specific revision (must be ISO 8601 format)
+$archivename = $file->getArchivename('2016-11-22T33:44:55Z');
+```
+
+### Deleting...
+
+If the account you're using has delete permissions, you can delete files as well:
+
+```php
+$file = $wiki->getFile('Old-button.png');
 // returns true if the delete was successful
-$page->delete('The button was superseded by a new one');
+$file->delete('The button was superseded by a new one');
+```
+
+To delete a specific older revision of the file, the archive name is needed:
+
+```php
+$file = $wiki->getFile('Often-changed-file.zip');
+$history = $file->getHistory(true);
+$archivename = $file->getArchivename(3);
+$file->delete('This was an inadvertent release', $archivename);
 ```
 
 ### Other stuff

--- a/USAGE.md
+++ b/USAGE.md
@@ -233,7 +233,7 @@ $result = uploadFromUrl('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.
 The revision history of a file can be obtained as an array with a properties array per revision:
 
 ```php
-$file = $wiki->getFile('Often-changed-file.zip');
+$file = $wiki->getFile('Frequently-changed-file.zip');
 // get only the current revision
 $history = $file->getHistory();
 // get the maximum number of revisions (500 for user accounts, 5000 for bot accounts)

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -929,7 +929,7 @@ class WikiPage
 
 		// Return error message and value
 		$this->error = array();
-		$this->error['page'] = 'The section is not found on this page';
+		$this->error['page'] = "Section '$section' was not found on this page";
 		return -1;
 	}
 }
@@ -1373,7 +1373,8 @@ class WikiFile
 	 * Revision can be the following:
 	 * - revision timestamp (string:"2001-01-15T14:56:00Z")
 	 * - revision index (int:3)
-	 * The current revision has index 0.
+	 * The most recent revision has index 0, it increments towards
+	 * older revisions.  A timestamp must be in ISO 8601 format.
 	 *
 	 * @param   mixed  $revision  The index or timestamp of the revision
 	 * @return  mixed             The properties (array), or null if not found
@@ -1396,7 +1397,7 @@ class WikiFile
 
 		// Return error message
 		$this->error = array();
-		$this->error['file'] = 'The revision is not found for this file';
+		$this->error['file'] = "Revision '$revision' was not found for this file";
 		return null;
 	}
 
@@ -1406,7 +1407,8 @@ class WikiFile
 	 * Revision can be the following:
 	 * - revision timestamp (string:"2001-01-15T14:56:00Z")
 	 * - revision index (int:3)
-	 * The current revision has index 0.
+	 * The most recent revision has index 0, it increments towards
+	 * older revisions.  A timestamp must be in ISO 8601 format.
 	 *
 	 * @param   mixed  $revision  The index or timestamp of the revision
 	 * @return  mixed             The archive name (string), or null if not found
@@ -1430,7 +1432,7 @@ class WikiFile
 	}
 
 	/**
-	 * Delete the file, or an older revision of it.
+	 * Delete the file, or only an older revision of it.
 	 *
 	 * @param   string   $reason       Reason for the deletion
 	 * @param   string   $archivename  The archive name of the older revision


### PR DESCRIPTION
See #72. Before, `getInfo()` only obtains the current revision, and I wanted to keep that the default as this suffices for most use cases, and it would be unnecessary strain on the MW API to always get all revisions. I struggled for a little while how to combine MW API's abilities regarding file revisions with Wikimate's caching approach (`getInfo()`'s `$refresh` parameter), but eventually settled on the following.

Enter `getHistory()` which by default just returns the same current revision but, if forced to refresh, can fetch the desired number of revisions or the max, and from the current revision backwards or using the timestamp(s). See the [API doc](https://www.mediawiki.org/wiki/API:Imageinfo#Parameters).

In the resulting history array, the keys are numbered from 0 upwards, and can subsequently be used to fetch one revision's properties array via `getRevision()` as well as an older revision's archive name via `getArchivename()`. If the history includes the current revision, which has no archive name, `getArchivename()` treats that as an error. If it doesn't include the current revision because of timestamp parameters, key 0 refers to the most recent revision in the selection.

The revision parameter can also be a timestamp, but this needs to be the exact one used in the properties. I tried to be more flexible and allow other formats, but translating them into ISO8601 in PHP code and then matching that against the cached property was problematic, also because of timezone settings/conversions. So I decided to keep it simple and clear by sticking to exact timestamp matches only.

The new `delete()` defines the File: page path itself now and optionally takes an archive name to delete an older revision, which affects (or doesn't affect) the `$exists` flag too.