### PR TITLE
Modernize token handling (fixes #99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,20 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 * New GOVERNANCE.md file to explicitly codify the project management principles and provide guidelines for maintenance tasks ([#83])
 
+#### Changed
+
+* Modernize token handling for login and data-modifying actions ([#100])
+
 #### Fixed
 
-* Prevented PHP notice in `WikiFile::getInfo()` for moved or deleted file. ([#85])
+* Prevented PHP notice in `WikiFile::getInfo()` for moved or deleted file ([#85])
 
 ### Version 0.12.0
 
 #### Added
 
 * New class WikiFile to retrieve properties of a file, and download and upload its contents.  All properties pertain to the current revision of the file, or a specific older revision. ([#69], [#71], [#78], [#80])
-* WikiFile also provides the file history and the ability to delete a file or an older revision of it. ([#76])
+* WikiFile also provides the file history and the ability to delete a file or an older revision of it ([#76])
 
 ### Version 0.11.0
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -63,6 +63,9 @@ class Wikimate
 
 	/**
 	 * Obtains a wiki token for logging in or data-modifying actions.
+	 * For now this method, in Wikimate tradition, is kept simple and supports
+	 * only the two token types needed elsewhere in the library.  It also
+	 * doesn't support the option to request multiple tokens at once.
 	 *
 	 * @param   string  $type  The token type
 	 * @return  string         The requested token

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -124,8 +124,6 @@ class Wikimate
 	 */
 	public function login($username, $password, $domain = null)
 	{
-		//Logger::log("Logging in");
-
 		// Obtain login token first
 		if (($logintoken = $this->token(self::TOKEN_LOGIN)) === false) {
 			return false;
@@ -169,8 +167,6 @@ class Wikimate
 		}
 
 		if (isset($loginResult->login->result) && $loginResult->login->result != 'Success') {
-			//Logger::log("Sending token {$loginResult->login->token}");
-
 			// Some more comprehensive error checking
 			$this->error = array();
 			switch ($loginResult->login->result) {
@@ -184,7 +180,6 @@ class Wikimate
 			return false;
 		}
 
-		//Logger::log("Logged in");
 		return true;
 	}
 


### PR DESCRIPTION
The action token handling is [deprecated](https://www.mediawiki.org/wiki/API:Tokens_(action)) since MW v1.24. This PR restructures all three Wikimate classes to use the current [meta tokens approach](https://www.mediawiki.org/wiki/API:Tokens). That includes the login token, which was only introduced in MW v1.27. Wikimate deployments prior to that version can continue to use the v0.12.0 tag.