### PR TITLE
Prepare for v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 #### Changed
 
-* Modernize token handling for login and data-modifying actions ([#100], [#106])
+* Modernized token handling for login and data-modifying actions. Requires MediaWiki v1.27 or newer. ([#100], [#106])
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 ### Upcoming version
 
+No changes yet.
+
+### Version 0.13.0 - 2021-07-05
+
 #### Added
 
 * Added more debug logging of MediaWiki requests and responses ([#101], [#106])

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It currently consists of three classes:
 * **WikiFile** – Provides an interface to downloading/uploading files and getting their properties.
 
 The [latest released version](https://github.com/hamstar/Wikimate/releases) of Wikimate
-is v0.12.0, released on Feb 3, 2017.
+is v0.13.0, released on Jul 5, 2021. It requires MediaWiki v1.27 or newer.
 See [CHANGELOG.md](CHANGELOG.md) for the detailed version history.
 
 ## Installation
@@ -26,7 +26,7 @@ Then, download Wikimate, and initialise it by running `composer install` (or
 To use Wikimate within another project, you can add it as a composer dependency
 by adding the following to your `composer.json` file:
 
-    "hamstar/Wikimate": "0.12.0"
+    "hamstar/Wikimate": "0.13.0"
 
 ## Usage
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -2,7 +2,7 @@
 /// =============================================================================
 /// Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
 ///
-/// @version    0.12.0
+/// @version    0.13.0
 /// @copyright  SPDX-License-Identifier: MIT
 /// =============================================================================
 
@@ -17,7 +17,7 @@ class Wikimate
 	/**
 	 * @var  string  The current version number (conforms to http://semver.org/).
 	 */
-	const VERSION = '0.12.0';
+	const VERSION = '0.13.0';
 
 	const TOKEN_DEFAULT = 'csrf';
 	const TOKEN_LOGIN   = 'login';


### PR DESCRIPTION
I'm working on maxlag support which brings about significant code changes, so it's good to first create a stable release of where we are now.

If @waldyrious continues to be unavailable that's okay, but in absence of another active collaborator that means I'll have to keep merging my own PRs, in spite of this repo's governance guidelines. I intend to wrap this up on Sunday July 4.