### PR TITLE
Update governance guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 
-### Unreleased version
+### Upcoming version
 
 #### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 #### Added
 
 * Added more debug logging of MediaWiki requests and responses ([#101])
-* New GOVERNANCE.md file to explicitly codify the project management principles and provide guidelines for maintenance tasks ([#83])
+* New GOVERNANCE.md file to explicitly codify the project management principles and provide guidelines for maintenance tasks ([#83], [#105])
 
 #### Changed
 
@@ -106,4 +106,4 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#85]: https://github.com/hamstar/Wikimate/pull/85
 [#100]: https://github.com/hamstar/Wikimate/pull/100
 [#101]: https://github.com/hamstar/Wikimate/pull/101
-
+[#105]: https://github.com/hamstar/Wikimate/pull/105

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,14 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 * Prevented PHP notice in `WikiFile::getInfo()` for moved or deleted file ([#85])
 
-### Version 0.12.0
+### Version 0.12.0 - 2017-02-03
 
 #### Added
 
 * New class WikiFile to retrieve properties of a file, and download and upload its contents.  All properties pertain to the current revision of the file, or a specific older revision. ([#69], [#71], [#78], [#80])
 * WikiFile also provides the file history and the ability to delete a file or an older revision of it ([#76])
 
-### Version 0.11.0
+### Version 0.11.0 - 2016-11-16
 
 #### Added
 
@@ -48,7 +48,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 * Fixed passing the return value in `WikiPage::setSection()` ([#30])
 * Corrected call to `Wikimate::debugRequestsConfig()` ([#30])
 
-### Version 0.10.0
+### Version 0.10.0 - 2014-06-24
 
 #### Changed
 
@@ -58,14 +58,14 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 * Bumped version for stable release
 
-### Version 0.5
+### Version 0.5 - 2011-09-09
 
 * Removed the use of constants in favour of constructor arguments
 * Added checks that throw an exception if can't write to wikimate_cookie.txt
 * Throws exception if curl library not loaded
 * Throws exception if can't login
 
-### Version 0.4
+### Version 0.4 - 2011-01-15
 
 * Added `WikiPage::newSection()` and `WikiPage::setSection()` (shortcuts to `WikiPage::setText()`)
 * Added the ability to get individual sections of the article with `WikiPage::getSection()`
@@ -73,7 +73,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 * Added the ability to get array showing section offsets and lengths in the page wikicode with `WikiPage::getSectionOffsets()`
 * Added the ability to see how many sections are on a page with `WikiPage::getNumSections()`
 
-### Version 0.3
+### Version 0.3 - 2010-12-26
 
 * Initial commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 * Switched to using the *Requests* library instead of Curl ([#25])
 
+### Version 0.9 - 2014-06-13
+
+* Bumped version for stable release
+
 ### Version 0.5
 
 * Removed the use of constants in favour of constructor arguments
@@ -100,4 +104,6 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#80]: https://github.com/hamstar/Wikimate/pull/80
 [#83]: https://github.com/hamstar/Wikimate/pull/83
 [#85]: https://github.com/hamstar/Wikimate/pull/85
+[#100]: https://github.com/hamstar/Wikimate/pull/100
+[#101]: https://github.com/hamstar/Wikimate/pull/101
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ A PR should be created with all relevant changes to update the repository for th
 It should apply the following actions:
 
 1. Change the "Upcoming version" heading in the CHANGELOG.md file
-   to the appropriate version name (e.g. "Version 1.2.3")
+   to the appropriate version name and date (e.g. "Version 1.2.3 - 2020-12-31")
    and add a new "Upcoming version" section heading above it,
    with the contents "No changes yet.";
 2. Edit the README and replace all references

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,7 +24,7 @@ if they would like to help maintaining the repository.
 4. **Commits should be atomic**
    (as small as possible while still representing a self-consistent set of changes)
    and have descriptive commit messages.
-5. **Every PR should include a CHANGELOG.md entry**.
+5. **Every PR should include a `CHANGELOG.md` entry**.
    This makes it much easier to prepare releases,
    and allows the change author to properly summarize it.
 
@@ -34,14 +34,14 @@ A PR should be created with all relevant changes to update the repository for th
 (See [#81](https://github.com/hamstar/Wikimate/pull/81) for an example.)
 It should apply the following actions:
 
-1. Change the "Upcoming version" heading in the CHANGELOG.md file
+1. Change the "Upcoming version" heading in the `CHANGELOG.md` file
    to the appropriate version name and date (e.g. "Version 1.2.3 - 2020-12-31")
    and add a new "Upcoming version" section heading above it,
    with the contents "No changes yet.";
 2. Edit the README and replace all references
    to the previous version number and release date
    with the corresponding data for the new version;
-3. Update all version references in Wikimate.php
+3. Update all version references in `Wikimate.php`
    to the new version.
 
 Once this PR is merged, a new release should be created
@@ -52,4 +52,4 @@ The version tag and the title of the release notes should be in the format v1.2.
 (following [SemVer](http://semver.org/) conventions
 to determine which part of the version number to increase).
 The body of the release notes should be a summary of the contents
-of the relevant section in CHANGELOG.md.
+of the relevant section in `CHANGELOG.md`.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,9 +34,10 @@ A PR should be created with all relevant changes to update the repository for th
 (See [#81](https://github.com/hamstar/Wikimate/pull/81) for an example.)
 It should apply the following actions:
 
-1. Change the "Unreleased version" heading in the CHANGELOG.md file
+1. Change the "Upcoming version" heading in the CHANGELOG.md file
    to the appropriate version name (e.g. "Version 1.2.3")
-   and add a new "Unreleased version" section heading above it;
+   and add a new "Upcoming version" section heading above it,
+   with the contents "No changes yet.";
 2. Edit the README and replace all references
    to the previous version number and release date
    with the corresponding data for the new version;

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,6 +15,8 @@ if they would like to help maintaining the repository.
    (except for very minor ones such as spelling fixes).
 2. **Maintainers should not merge their own pull requests**.
    This allows every change to be validated by at least another maintainer.
+   That said, if there's no input by other maintainers in over a week,
+   the maintainer who authored the pull request can merge their own PR.
 3. Pull requests should comprise a single feature or bugfix.
    **Unrelated changes should be sent as separate PRs.**
    The exception are minor code cleanup changes,


### PR DESCRIPTION
- Add missing content to CHANGELOG.md (version 0.9, and reference links for #100 and #101)
- Add a provision to unblock PRs when only one maintainer is available
- Change title of CHANGELOG section for untagged changes, and define default content for it
- Add dates for released versions in CHANGELOG.md

See the relevant discussions in #102 for context.