### PR TITLE
Assorted fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,17 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 #### Added
 
-* Added more debug logging of MediaWiki requests and responses ([#101])
+* Added more debug logging of MediaWiki requests and responses ([#101], [#106])
 * New GOVERNANCE.md file to explicitly codify the project management principles and provide guidelines for maintenance tasks ([#83], [#105])
 
 #### Changed
 
-* Modernize token handling for login and data-modifying actions ([#100])
+* Modernize token handling for login and data-modifying actions ([#100], [#106])
 
 #### Fixed
 
 * Prevented PHP notice in `WikiFile::getInfo()` for moved or deleted file ([#85])
+* Fixed capitalization of a built-in PHP class in a comment ([#106])
 
 ### Version 0.12.0 - 2017-02-03
 
@@ -107,3 +108,4 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#100]: https://github.com/hamstar/Wikimate/pull/100
 [#101]: https://github.com/hamstar/Wikimate/pull/101
 [#105]: https://github.com/hamstar/Wikimate/pull/105
+[#106]: https://github.com/hamstar/Wikimate/pull/106

--- a/USAGE.md
+++ b/USAGE.md
@@ -300,6 +300,7 @@ print_r($page->getError());
 
 For MediaWiki API errors, the array contains the 'code' and 'info' key/value pairs [defined by the API](https://www.mediawiki.org/wiki/API:Errors_and_warnings#Errors).  For other errors, the following key/value pairs are returned:
 * 'login' for Wikimate authentication problems
+* 'token' for Wikimate token problems
 * 'page' for WikiPage errors
 * 'file' for WikiFile errors
 
@@ -309,7 +310,6 @@ You can use the edit and query commands in Wikimate:
 ```php
 $data = array(
 	'prop' => 'info|revisions',
-	'intoken' => 'edit',
 	'titles' => 'this|that|other'
 );
 
@@ -318,7 +318,6 @@ $array_result = $wiki->query($data);
 
 $data = array(
 	'title' => 'this',
-	'token' => '+\\', // this is urlencoded automatically
 	'etc' => 'stuff'
 );
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -610,7 +610,7 @@ class WikiPage
 	/**
 	 * Returns the sections offsets and lengths.
 	 *
-	 * @return  StdClass  Section class
+	 * @return  stdClass  Section class
 	 */
 	public function getSectionOffsets()
 	{

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -75,7 +75,7 @@ class Wikimate
 		// Check for supported token types
 		if ($type != self::TOKEN_DEFAULT && $type != self::TOKEN_LOGIN) {
 			$this->error = array();
-			$this->error['login'] = 'The API does not support the token type';
+			$this->error['token'] = 'The API does not support the token type';
 			return false;
 		}
 
@@ -91,7 +91,7 @@ class Wikimate
 		// Check if we got an API result or the API doc page (invalid request)
 		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
 			$this->error = array();
-			$this->error['login'] = 'The API could not understand the token request';
+			$this->error['token'] = 'The API could not understand the token request';
 			return false;
 		}
 
@@ -99,7 +99,7 @@ class Wikimate
 		// Check if we got a JSON result
 		if ($tokenResult === null) {
 			$this->error = array();
-			$this->error['login'] = 'The API did not return the token response';
+			$this->error['token'] = 'The API did not return the token response';
 			return false;
 		}
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -301,7 +301,7 @@ class Wikimate
 
 		if ($this->debugMode) {
 			echo "parse GET response:\n";
-			print_r(json_decode($apiResult->body));
+			print_r(unserialize($apiResult->body));
 		}
 		return unserialize($apiResult->body);
 	}

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -66,6 +66,8 @@ class Wikimate
 	 * For now this method, in Wikimate tradition, is kept simple and supports
 	 * only the two token types needed elsewhere in the library.  It also
 	 * doesn't support the option to request multiple tokens at once.
+	 * See https://www.mediawiki.org/wiki/Special:MyLanguage/API:Tokens
+	 * for more information.
 	 *
 	 * @param   string  $type  The token type
 	 * @return  string         The requested token


### PR DESCRIPTION
Follow-ups to PR #100:
- 2f7991d fixes a copy/paste mistake in commit 5044fd7
- 8c8edbf updates the documentation to match the PR changes
- b935d45 expands documentation for the `token()` function, as discussed [here](https://github.com/hamstar/Wikimate/pull/100#issuecomment-872789926)

Other changes:
- 52f02a8 is an isolated capitalization fix, not associated with any recent PR
- 9d40318 is a fix to commit 6674d67, from PR #101

All of these fixes were authored by @Xymph, and are being extracted from #102 to keep that one focused on the release preparations.