### PR TITLE
Add missing PHPDoc comments for properties, constants, and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 #### Added
 
 * Support for getting/setting user agent for API requests ([#107])
+* Added missing PHPDoc comments for properties, constants, and more ([#109])
 
 #### Changed
 
@@ -121,3 +122,4 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#106]: https://github.com/hamstar/Wikimate/pull/106
 [#107]: https://github.com/hamstar/Wikimate/pull/107
 [#108]: https://github.com/hamstar/Wikimate/pull/108
+[#109]: https://github.com/hamstar/Wikimate/pull/109

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 ## MIT License
 
-Copyright (c) 2014 Robert McLeod and [contributors](https://github.com/hamstar/Wikimate/graphs/contributors)
+Copyright (c) 2010-2021 Robert McLeod, Frans P. de Vries, and
+[contributors](https://github.com/hamstar/Wikimate/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -15,22 +15,81 @@
 class Wikimate
 {
 	/**
-	 * @var  string  The current version number (conforms to http://semver.org/).
+	 * The current version number (conforms to Semantic Versioning)
+	 *
+	 * @var string
+	 * @link https://semver.org/
 	 */
 	const VERSION = '0.13.0';
 
+	/**
+	 * Identifier for CSRF token
+	 *
+	 * @var string
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Tokens
+	 */
 	const TOKEN_DEFAULT = 'csrf';
-	const TOKEN_LOGIN   = 'login';
 
+	/**
+	 * Identifier for Login token
+	 *
+	 * @var string
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Tokens
+	 */
+	const TOKEN_LOGIN = 'login';
+
+	/**
+	 * Base URL for API requests
+	 *
+	 * @var string
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Main_page#Endpoint
+	 */
 	protected $api;
+
+	/**
+	 * Username for API requests
+	 *
+	 * @var string
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Login#Method_1._login
+	 */
 	protected $username;
+
+	/**
+	 * Password for API requests
+	 *
+	 * @var string
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Login#Method_1._login
+	 */
 	protected $password;
 
-	/** @var  Requests_Session */
+	/**
+	 * Session object for HTTP requests
+	 *
+	 * @var Requests_Session
+	 * @link https://requests.ryanmccue.info/
+	 */
 	protected $session;
+
+	/**
+	 * User agent string for Requests_Session
+	 *
+	 * @var string
+	 * @link https://requests.ryanmccue.info/docs/usage-advanced.html#session-handling
+	 */
 	protected $useragent;
 
-	protected $error     = null;
+	/**
+	 * Error array with API and Wikimate errors
+	 *
+	 * @var array|null
+	 */
+	protected $error = null;
+
+	/**
+	 * Whether to output debug logging
+	 *
+	 * @var boolean
+	 */
 	protected $debugMode = false;
 
 	/**
@@ -500,18 +559,82 @@ class Wikimate
  */
 class WikiPage
 {
+	/**
+	 * Use section indexes as keys in return array of {@link WikiPage::getAllSections()}
+	 *
+	 * @var integer
+	 */
 	const SECTIONLIST_BY_INDEX = 1;
+
+	/**
+	 * Use section names as keys in return array of {@link WikiPage::getAllSections()}
+	 *
+	 * @var integer
+	 */
 	const SECTIONLIST_BY_NAME = 2;
+
+	/**
+	 * Use section numbers as keys in return array of {@link WikiPage::getAllSections()}
+	 *
+	 * @var integer
+	 */
 	const SECTIONLIST_BY_NUMBER = 3;
 
-	protected $title          = null;
-	protected $wikimate       = null;
-	protected $exists         = false;
-	protected $invalid        = false;
-	protected $error          = null;
+	/**
+	 * The title of the page
+	 *
+	 * @var string|null
+	 */
+	protected $title = null;
+
+	/**
+	 * Wikimate object for API requests
+	 *
+	 * @var Wikimate|null
+	 */
+	protected $wikimate = null;
+
+	/**
+	 * Whether the page exists
+	 *
+	 * @var boolean
+	 */
+	protected $exists = false;
+
+	/**
+	 * Whether the page is invalid
+	 *
+	 * @var boolean
+	 */
+	protected $invalid = false;
+
+	/**
+	 * Error array with API and WikiPage errors
+	 *
+	 * @var array|null
+	 */
+	protected $error = null;
+
+	/**
+	 * Stores the timestamp for detection of edit conflicts
+	 *
+	 * @var integer|null
+	 */
 	protected $starttimestamp = null;
-	protected $text           = null;
-	protected $sections       = null;
+
+	/**
+	 * The complete text of the page
+	 *
+	 * @var string|null
+	 */
+	protected $text = null;
+
+	/**
+	 * The sections object for the page
+	 *
+	 * @var stdClass|null
+	 */
+	protected $sections = null;
 
 	/*
 	 *
@@ -1081,13 +1204,56 @@ class WikiPage
  */
 class WikiFile
 {
+	/**
+	 * The name of the file
+	 *
+	 * @var string|null
+	 */
 	protected $filename = null;
+
+	/**
+	 * Wikimate object for API requests
+	 *
+	 * @var Wikimate|null
+	 */
 	protected $wikimate = null;
-	protected $exists   = false;
-	protected $invalid  = false;
-	protected $error    = null;
-	protected $info     = null;
-	protected $history  = null;
+
+	/**
+	 * Whether the file exists
+	 *
+	 * @var boolean
+	 */
+	protected $exists = false;
+
+	/**
+	 * Whether the file is invalid
+	 *
+	 * @var boolean
+	 */
+	protected $invalid = false;
+
+	/**
+	 * Error array with API and WikiFile errors
+	 *
+	 * @var array|null
+	 */
+	protected $error = null;
+
+	/**
+	 * Image info for the current file revision
+	 *
+	 * @var array|null
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Imageinfo
+	 */
+	protected $info = null;
+
+	/**
+	 * Image info for all file revisions
+	 *
+	 * @var array|null
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Imageinfo
+	 */
+	protected $history = null;
 
 	/*
 	 *

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -95,6 +95,10 @@ class Wikimate
 	/**
 	 * Creates a new Wikimate object.
 	 *
+	 * @param   string    $api      Base URL for the API
+	 * @param   array     $headers  Default headers for API requests
+	 * @param   array     $data     Default data for API requests
+	 * @param   array     $options  Default options for API requests
 	 * @return  Wikimate
 	 */
 	public function __construct($api, $headers = array(), $data = array(), $options = array())
@@ -185,6 +189,7 @@ class Wikimate
 	 * @param   string   $password  The user password
 	 * @param   string   $domain    The domain (optional)
 	 * @return  boolean             True if logged in
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Login#Method_1._login
 	 */
 	public function login($username, $password, $domain = null)
 	{
@@ -350,6 +355,7 @@ class Wikimate
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
 	 * @return  array          Unserialized php output from the wiki API
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Query
 	 */
 	public function query($array)
 	{
@@ -374,6 +380,7 @@ class Wikimate
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
 	 * @return  array          Unserialized php output from the wiki API
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Parsing_wikitext
 	 */
 	public function parse($array)
 	{
@@ -398,6 +405,7 @@ class Wikimate
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
 	 * @return  array          Unserialized php output from the wiki API
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Edit
 	 */
 	public function edit($array)
 	{
@@ -432,6 +440,7 @@ class Wikimate
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
 	 * @return  array          Unserialized php output from the wiki API
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Delete
 	 */
 	public function delete($array)
 	{
@@ -489,6 +498,7 @@ class Wikimate
 	 *
 	 * @param   array    $array  Array of details to be used in the upload
 	 * @return  array            Unserialized php output from the wiki API
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Upload
 	 */
 	public function upload($array)
 	{

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -1,15 +1,18 @@
 <?php
-/// =============================================================================
-/// Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
-///
-/// @version    0.13.0
-/// @copyright  SPDX-License-Identifier: MIT
-/// =============================================================================
+/**
+ * =============================================================================
+ * Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
+ *
+ * @package    Wikimate
+ * @version    0.13.0
+ * @copyright  SPDX-License-Identifier: MIT
+ * =============================================================================
+ */
 
 /**
  * Provides an interface over wiki API objects such as pages and files.
  *
- * @author  Robert McLeod
+ * @author  Robert McLeod & Frans P. de Vries
  * @since   December 2010
  */
 class Wikimate
@@ -564,7 +567,7 @@ class Wikimate
 /**
  * Models a wiki article page that can have its text altered and retrieved.
  *
- * @author  Robert McLeod
+ * @author  Robert McLeod & Frans P. de Vries
  * @since   December 2010
  */
 class WikiPage

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -587,13 +587,6 @@ class WikiPage
 	const SECTIONLIST_BY_NAME = 2;
 
 	/**
-	 * Use section numbers as keys in return array of {@link WikiPage::getAllSections()}
-	 *
-	 * @var integer
-	 */
-	const SECTIONLIST_BY_NUMBER = 3;
-
-	/**
 	 * The title of the page
 	 *
 	 * @var string|null


### PR DESCRIPTION
Running PHPDoc (v2.9.1) highlighted that most class properties and constants were lacking comments, and existing ones were incomplete. Also, parameters to the Wikimate constructor method weren't documented, and the main file header was misformatted using /// comments.