### PR TITLE
Change API requests from deprecated PHP format to JSON format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 #### Changed
 
+* Changed API requests from deprecated PHP format to JSON format ([#111])
 * Grouped sections and added table of contents in USAGE.md ([#108])
 
 ### Version 0.13.0 - 2021-07-05
@@ -123,3 +124,4 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#107]: https://github.com/hamstar/Wikimate/pull/107
 [#108]: https://github.com/hamstar/Wikimate/pull/108
 [#109]: https://github.com/hamstar/Wikimate/pull/109
+[#111]: https://github.com/hamstar/Wikimate/pull/111

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -163,7 +163,7 @@ class Wikimate
 			return false;
 		}
 
-		$tokenResult = json_decode($response->body);
+		$tokenResult = json_decode($response->body, true);
 		// Check if we got a JSON result
 		if ($tokenResult === null) {
 			$this->error = array();
@@ -179,9 +179,9 @@ class Wikimate
 		}
 
 		if ($type == self::TOKEN_LOGIN) {
-			return $tokenResult->query->tokens->logintoken;
+			return $tokenResult['query']['tokens']['logintoken'];
 		} else {
-			return $tokenResult->query->tokens->csrftoken;
+			return $tokenResult['query']['tokens']['csrftoken'];
 		}
 	}
 
@@ -223,7 +223,7 @@ class Wikimate
 			return false;
 		}
 
-		$loginResult = json_decode($response->body);
+		$loginResult = json_decode($response->body, true);
 		// Check if we got a JSON result
 		if ($loginResult === null) {
 			$this->error = array();
@@ -238,15 +238,15 @@ class Wikimate
 			print_r($loginResult);
 		}
 
-		if (isset($loginResult->login->result) && $loginResult->login->result != 'Success') {
+		if (isset($loginResult['login']['result']) && $loginResult['login']['result'] != 'Success') {
 			// Some more comprehensive error checking
 			$this->error = array();
-			switch ($loginResult->login->result) {
+			switch ($loginResult['login']['result']) {
 				case 'Failed':
 					$this->error['login'] = 'Incorrect username or password';
 					break;
 				default:
-					$this->error['login'] = 'The API result was: ' . $loginResult->login->result;
+					$this->error['login'] = 'The API result was: ' . $loginResult['login']['result'];
 					break;
 			}
 			return false;

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -357,13 +357,13 @@ class Wikimate
 	 * Performs a query to the wiki API with the given details.
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
-	 * @return  array          Unserialized php output from the wiki API
+	 * @return  array          Decoded JSON output from the wiki API
 	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Query
 	 */
 	public function query($array)
 	{
 		$array['action'] = 'query';
-		$array['format'] = 'php';
+		$array['format'] = 'json';
 
 		if ($this->debugMode) {
 			echo "query GET parameters:\n";
@@ -373,22 +373,22 @@ class Wikimate
 
 		if ($this->debugMode) {
 			echo "query GET response:\n";
-			print_r(unserialize($apiResult->body));
+			print_r(json_decode($apiResult->body, true));
 		}
-		return unserialize($apiResult->body);
+		return json_decode($apiResult->body, true);
 	}
 
 	/**
 	 * Performs a parse query to the wiki API.
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
-	 * @return  array          Unserialized php output from the wiki API
+	 * @return  array          Decoded JSON output from the wiki API
 	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Parsing_wikitext
 	 */
 	public function parse($array)
 	{
 		$array['action'] = 'parse';
-		$array['format'] = 'php';
+		$array['format'] = 'json';
 
 		if ($this->debugMode) {
 			echo "parse GET parameters:\n";
@@ -398,16 +398,16 @@ class Wikimate
 
 		if ($this->debugMode) {
 			echo "parse GET response:\n";
-			print_r(unserialize($apiResult->body));
+			print_r(json_decode($apiResult->body, true));
 		}
-		return unserialize($apiResult->body);
+		return json_decode($apiResult->body, true);
 	}
 
 	/**
 	 * Perfoms an edit query to the wiki API.
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
-	 * @return  array          Unserialized php output from the wiki API
+	 * @return  array          Decoded JSON output from the wiki API
 	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Edit
 	 */
 	public function edit($array)
@@ -422,7 +422,7 @@ class Wikimate
 		);
 
 		$array['action'] = 'edit';
-		$array['format'] = 'php';
+		$array['format'] = 'json';
 		$array['token'] = $edittoken;
 
 		if ($this->debugMode) {
@@ -433,16 +433,16 @@ class Wikimate
 
 		if ($this->debugMode) {
 			echo "edit POST response:\n";
-			print_r(unserialize($apiResult->body));
+			print_r(json_decode($apiResult->body, true));
 		}
-		return unserialize($apiResult->body);
+		return json_decode($apiResult->body, true);
 	}
 
 	/**
 	 * Perfoms a delete query to the wiki API.
 	 *
 	 * @param   array  $array  Array of details to be passed in the query
-	 * @return  array          Unserialized php output from the wiki API
+	 * @return  array          Decoded JSON output from the wiki API
 	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Delete
 	 */
 	public function delete($array)
@@ -457,7 +457,7 @@ class Wikimate
 		);
 
 		$array['action'] = 'delete';
-		$array['format'] = 'php';
+		$array['format'] = 'json';
 		$array['token'] = $deletetoken;
 
 		if ($this->debugMode) {
@@ -468,9 +468,9 @@ class Wikimate
 
 		if ($this->debugMode) {
 			echo "delete POST response:\n";
-			print_r(unserialize($apiResult->body));
+			print_r(json_decode($apiResult->body, true));
 		}
-		return unserialize($apiResult->body);
+		return json_decode($apiResult->body, true);
 	}
 
 	/**
@@ -500,7 +500,7 @@ class Wikimate
 	 * Uploads a file to the wiki API.
 	 *
 	 * @param   array    $array  Array of details to be used in the upload
-	 * @return  array            Unserialized php output from the wiki API
+	 * @return  array            Decoded JSON output from the wiki API
 	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Upload
 	 */
 	public function upload($array)
@@ -511,7 +511,7 @@ class Wikimate
 		}
 
 		$array['action'] = 'upload';
-		$array['format'] = 'php';
+		$array['format'] = 'json';
 		$array['token'] = $uploadtoken;
 
 		// Construct multipart body:
@@ -547,9 +547,9 @@ class Wikimate
 
 		if ($this->debugMode) {
 			echo "upload POST response:\n";
-			print_r(unserialize($apiResult->body));
+			print_r(json_decode($apiResult->body, true));
 		}
-		return unserialize($apiResult->body);
+		return json_decode($apiResult->body, true);
 	}
 
 	/**


### PR DESCRIPTION
PHP format is [deprecated](https://www.mediawiki.org/wiki/API:Data_formats#Output) and only maintained for now due to [its popularity](https://www.mediawiki.org/wiki/API:Data_formats#Additional_notes). New users should stick [to JSON](https://www.mediawiki.org/wiki/API:Etiquette#Data_formats), and some API calls [like opensearch](https://www.mediawiki.org/wiki/API:Opensearch) don't even support PHP format. See PR #104 for further discussion.

The Wikimate methods return nested associative arrays, which were produced by [unserialize](https://www.php.net/manual/en/function.unserialize) from the PHP format. Fortunately, while [json_decode](https://www.php.net/manual/en/function.json-decode) normally returns a stdClass object, setting the $associative flag will produce the same arrays.

Ideally this switch would be unit-tested with before/after comparisons, but that is beyond my expertise and available time. I have however run my client scripts with the switched format for a while and not encountered any issues.
