### PR TITLE
Support for the maxlag parameter (with retries) in API requests (fixes #92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 #### Added
 
+* Support for the maxlag parameter (with retries) in API requests ([#112])
 * Support for getting/setting user agent for API requests ([#107])
 * Added missing PHPDoc comments for properties, constants, and more ([#109])
 
@@ -129,4 +130,5 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#108]: https://github.com/hamstar/Wikimate/pull/108
 [#109]: https://github.com/hamstar/Wikimate/pull/109
 [#111]: https://github.com/hamstar/Wikimate/pull/111
+[#112]: https://github.com/hamstar/Wikimate/pull/112
 [#114]: https://github.com/hamstar/Wikimate/pull/114

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -10,6 +10,10 @@
 /**
  * Provides an interface over wiki API objects such as pages and files.
  *
+ * All requests to the API can throw an exception if the server is lagged
+ * and a finite number of retries is exhausted.  By default requests are
+ * tried indefinitely.  See {@see Wikimate::request()} for more information.
+ *
  * @author  Robert McLeod & Frans P. de Vries
  * @since   0.2  December 2010
  */

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -243,11 +243,11 @@ class Wikimate
 			'action' => 'query',
 			'meta' => 'tokens',
 			'type' => $type,
-			'format' => 'json'
 		);
 
 		// Send the token request
-		$response = $this->session->post($this->api, array(), $details);
+		$response = $this->request($details, array(), true);
+
 		// Check if we got an API result or the API doc page (invalid request)
 		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
 			$this->error = array();
@@ -298,7 +298,6 @@ class Wikimate
 			'lgname' => $username,
 			'lgpassword' => $password,
 			'lgtoken' => $logintoken,
-			'format' => 'json'
 		);
 
 		// If $domain is provided, set the corresponding detail in the request information array
@@ -307,7 +306,8 @@ class Wikimate
 		}
 
 		// Send the login request
-		$response = $this->session->post($this->api, array(), $details);
+		$response = $this->request($details, array(), true);
+
 		// Check if we got an API result or the API doc page (invalid request)
 		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
 			$this->error = array();
@@ -499,13 +499,12 @@ class Wikimate
 	public function query($array)
 	{
 		$array['action'] = 'query';
-		$array['format'] = 'json';
 
 		if ($this->debugMode) {
 			echo "query GET parameters:\n";
 			echo http_build_query($array) . "\n";
 		}
-		$apiResult = $this->session->get($this->api.'?'.http_build_query($array));
+		$apiResult = $this->request($array);
 
 		if ($this->debugMode) {
 			echo "query GET response:\n";
@@ -524,13 +523,12 @@ class Wikimate
 	public function parse($array)
 	{
 		$array['action'] = 'parse';
-		$array['format'] = 'json';
 
 		if ($this->debugMode) {
 			echo "parse GET parameters:\n";
 			echo http_build_query($array) . "\n";
 		}
-		$apiResult = $this->session->get($this->api.'?'.http_build_query($array));
+		$apiResult = $this->request($array);
 
 		if ($this->debugMode) {
 			echo "parse GET response:\n";
@@ -558,14 +556,13 @@ class Wikimate
 		);
 
 		$array['action'] = 'edit';
-		$array['format'] = 'json';
 		$array['token'] = $edittoken;
 
 		if ($this->debugMode) {
 			echo "edit POST parameters:\n";
 			print_r($array);
 		}
-		$apiResult = $this->session->post($this->api, $headers, $array);
+		$apiResult = $this->request($array, $headers, true);
 
 		if ($this->debugMode) {
 			echo "edit POST response:\n";
@@ -593,14 +590,13 @@ class Wikimate
 		);
 
 		$array['action'] = 'delete';
-		$array['format'] = 'json';
 		$array['token'] = $deletetoken;
 
 		if ($this->debugMode) {
 			echo "delete POST parameters:\n";
 			print_r($array);
 		}
-		$apiResult = $this->session->post($this->api, $headers, $array);
+		$apiResult = $this->request($array, $headers, true);
 
 		if ($this->debugMode) {
 			echo "delete POST response:\n";
@@ -648,6 +644,7 @@ class Wikimate
 
 		$array['action'] = 'upload';
 		$array['format'] = 'json';
+		$array['maxlag'] = $this->getMaxlag();
 		$array['token'] = $uploadtoken;
 
 		// Construct multipart body:
@@ -679,7 +676,7 @@ class Wikimate
 			'Content-Length' => strlen($body),
 		);
 
-		$apiResult = $this->session->post($this->api, $headers, $body);
+		$apiResult = $this->request($body, $headers, true);
 
 		if ($this->debugMode) {
 			echo "upload POST response:\n";

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -12,7 +12,7 @@
  *
  * All requests to the API can throw an exception if the server is lagged
  * and a finite number of retries is exhausted.  By default requests are
- * tried indefinitely.  See {@see Wikimate::request()} for more information.
+ * retried indefinitely.  See {@see Wikimate::request()} for more information.
  *
  * @author  Robert McLeod & Frans P. de Vries
  * @since   0.2  December 2010
@@ -114,7 +114,7 @@ class Wikimate
 	protected $maxlag = self::MAXLAG_DEFAULT;
 
 	/**
-	 * Maximum number of retries for lagged requests (-1 = indefinitely)
+	 * Maximum number of retries for lagged requests (-1 = retry indefinitely)
 	 *
 	 * @var integer
 	 */
@@ -157,11 +157,12 @@ class Wikimate
 	 *
 	 * This method handles maxlag errors as advised at:
 	 * {@see https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:Maxlag_parameter)
-	 * The request is sent with the current maxlag value (default 5 seconds).
+	 * The request is sent with the current maxlag value
+	 * (default: 5 seconds, per MAXLAG_DEFAULT).
 	 * If a lag error is received, the method waits (sleeps) for the
 	 * recommended time (per the Retry-After header), then tries again.
 	 * It will do this indefinitely unless the number of retries is limited,
-	 * in which case an exception is thrown.
+	 * in which case an exception is thrown once the limit is reached.
 	 *
 	 * The string type for $data is used only for upload POST requests,
 	 * and must contain the complete multipart body, including maxlag.
@@ -202,7 +203,7 @@ class Wikimate
 
 				if ($this->debugMode) {
 					preg_match('/Waiting for [^ ]*: ([0-9.-]+) seconds? lagged/', $response->body, $match);
-					echo "Server lagged for {$match[1]} seconds; retry in {$sleep} seconds\n";
+					echo "Server lagged for {$match[1]} seconds; will retry in {$sleep} seconds\n";
 				}
 				sleep($sleep);
 
@@ -210,7 +211,7 @@ class Wikimate
 				if ($this->getMaxretries() >= 0) {
 					$retries++;
 				} else {
-					$retries == -1; // continue indefinitely
+					$retries = -1; // continue indefinitely
 				}
 			}
 		} while ($server_lagged && $retries <= $this->getMaxretries());
@@ -352,7 +353,7 @@ class Wikimate
 	}
 
 	/**
-	 * Gets the current value for the maxlag parameter.
+	 * Gets the current value of the maxlag parameter.
 	 *
 	 * @return  integer  The maxlag value in seconds
 	 */
@@ -362,7 +363,7 @@ class Wikimate
 	}
 
 	/**
-	 * Sets the new value for the maxlag parameter.
+	 * Sets the new value of the maxlag parameter.
 	 *
 	 * @param   integer   $ml  The new maxlag value in seconds
 	 * @return  Wikimate       This object
@@ -374,7 +375,7 @@ class Wikimate
 	}
 
 	/**
-	 * Gets the current value for the max retries limit.
+	 * Gets the current value of the max retries limit.
 	 *
 	 * @return  integer  The max retries limit
 	 */
@@ -384,7 +385,7 @@ class Wikimate
 	}
 
 	/**
-	 * Sets the new value for the max retries limit.
+	 * Sets the new value of the max retries limit.
 	 *
 	 * @param   integer   $mr  The new max retries limit
 	 * @return  Wikimate       This object

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -40,6 +40,14 @@ class Wikimate
 	const TOKEN_LOGIN = 'login';
 
 	/**
+	 * Default lag value in seconds
+	 *
+	 * @var integer
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:Maxlag_parameter
+	 */
+	const MAXLAG_DEFAULT = 5;
+
+	/**
 	 * Base URL for API requests
 	 *
 	 * @var string
@@ -92,6 +100,21 @@ class Wikimate
 	 * @var boolean
 	 */
 	protected $debugMode = false;
+
+	/**
+	 * Maximum lag in seconds to accept in requests
+	 *
+	 * @var integer
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:Maxlag_parameter
+	 */
+	protected $maxlag = self::MAXLAG_DEFAULT;
+
+	/**
+	 * Maximum number of retries for lagged requests (-1 = indefinitely)
+	 *
+	 * @var integer
+	 */
+	protected $maxretries = -1;
 
 	/**
 	 * Creates a new Wikimate object.
@@ -251,6 +274,50 @@ class Wikimate
 		}
 
 		return true;
+	}
+
+	/**
+	 * Gets the current value for the maxlag parameter.
+	 *
+	 * @return  integer  The maxlag value in seconds
+	 */
+	public function getMaxlag()
+	{
+		return $this->maxlag;
+	}
+
+	/**
+	 * Sets the new value for the maxlag parameter.
+	 *
+	 * @param   integer   $ml  The new maxlag value in seconds
+	 * @return  Wikimate       This object
+	 */
+	public function setMaxlag($ml)
+	{
+		$this->maxlag = (int)$ml;
+		return $this;
+	}
+
+	/**
+	 * Gets the current value for the max retries limit.
+	 *
+	 * @return  integer  The max retries limit
+	 */
+	public function getMaxretries()
+	{
+		return $this->maxretries;
+	}
+
+	/**
+	 * Sets the new value for the max retries limit.
+	 *
+	 * @param   integer   $mr  The new max retries limit
+	 * @return  Wikimate       This object
+	 */
+	public function setMaxretries($mr)
+	{
+		$this->maxretries = (int)$mr;
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
This parameter insures that API requests can be dropped after the specified number of seconds by a replicated wiki server cluster (such as Wikipedia) if it is strained too much. If a maxlag response is returned, Wikimate delays (sleeps) for a given number of seconds before retrying the request. It can do this indefinitely, or for a limited number of retries. See the documentation at https://www.mediawiki.org/wiki/Manual:Maxlag_parameter

For the implementation I looked around at other PHP MediaWiki libraries for inspiration, and in the [bot functions table](https://en.wikipedia.org/wiki/Wikipedia:PHP_bot_functions) (linked from [here](https://en.wikipedia.org/wiki/Help:Creating_a_bot#PHP)) found an abandoned library called [Pillar](https://sourceforge.net/projects/pillar/). Here the [request class](https://sourceforge.net/p/pillar/code/HEAD/tree/trunk/class.mwrequest.php) offered a useful example of handling the lag.