### PR TITLE
Prepare for v0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 ### Upcoming version
 
+No changes yet.
+
+### Version 0.14.0 - 2021-08-24
+
 #### Added
 
 * Support for the maxlag parameter (with retries) in API requests ([#112])

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It currently consists of three classes:
 * **WikiFile** – Provides an interface to downloading/uploading files and getting their properties.
 
 The [latest released version](https://github.com/hamstar/Wikimate/releases) of Wikimate
-is v0.13.0, released on Jul 5, 2021. It requires MediaWiki v1.27 or newer.
+is v0.14.0, released on Aug 24, 2021. It requires MediaWiki v1.27 or newer.
 See [CHANGELOG.md](CHANGELOG.md) for the detailed version history.
 
 ## Installation
@@ -26,7 +26,7 @@ Then, download Wikimate, and initialise it by running `composer install` (or
 To use Wikimate within another project, you can add it as a composer dependency
 by adding the following to your `composer.json` file:
 
-    "hamstar/Wikimate": "0.13.0"
+    "hamstar/Wikimate": "0.14.0"
 
 ## Usage
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -3,7 +3,7 @@
  * Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
  *
  * @package    Wikimate
- * @version    0.13.0
+ * @version    0.14.0
  * @copyright  SPDX-License-Identifier: MIT
  */
 
@@ -25,7 +25,7 @@ class Wikimate
 	 * @var string
 	 * @link https://semver.org/
 	 */
-	const VERSION = '0.13.0';
+	const VERSION = '0.14.0';
 
 	/**
 	 * Identifier for CSRF token


### PR DESCRIPTION
Release summary:

"This release adds support for the maxlag parameter and for getting/setting the user agent, changes API calls from deprecated PHP format to JSON format, and improves PHPDoc commentary and USAGE.md.
It requires MediaWiki v1.27 or newer. For more details on these changes, including links to the corresponding pull requests, please check the Changelog."