### PR TITLE
Fix user agent format; add refs & changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 
 ### Upcoming version
 
-No changes yet.
+#### Fixed
+
+* Fixed format of user agent string ([#121])
 
 ### Version 0.14.0 - 2021-08-24
 
@@ -138,3 +140,4 @@ No changes yet.
 [#112]: https://github.com/hamstar/Wikimate/pull/112
 [#114]: https://github.com/hamstar/Wikimate/pull/114
 [#118]: https://github.com/hamstar/Wikimate/pull/118
+[#121]: https://github.com/hamstar/Wikimate/pull/121

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -88,6 +88,7 @@ class Wikimate
 	 *
 	 * @var string
 	 * @link https://requests.ryanmccue.info/docs/usage-advanced.html#session-handling
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Etiquette#The_User-Agent_header
 	 */
 	protected $useragent;
 
@@ -143,10 +144,12 @@ class Wikimate
 	 * Sets up a Requests_Session with appropriate user agent.
 	 *
 	 * @return  void
+	 * @link https://requests.ryanmccue.info/docs/usage-advanced.html#session-handling
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Etiquette#The_User-Agent_header
 	 */
 	protected function initRequests()
 	{
-		$this->useragent = 'Wikimate '.self::VERSION.' (https://github.com/hamstar/Wikimate)';
+		$this->useragent = 'Wikimate/'.self::VERSION.' (https://github.com/hamstar/Wikimate)';
 
 		$this->session = new Requests_Session($this->api, $this->headers, $this->data, $this->options);
 		$this->session->useragent = $this->useragent;
@@ -401,6 +404,7 @@ class Wikimate
 	 *
 	 * @return  string  The default user agent, or the current one defined
 	 *                  by {@see Wikimate::setUserAgent()}
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Etiquette#The_User-Agent_header
 	 */
 	public function getUserAgent()
 	{
@@ -415,6 +419,7 @@ class Wikimate
 	 *
 	 * @param   string   $ua  The new user agent
 	 * @return  Wikimate      This object
+	 * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Etiquette#The_User-Agent_header
 	 */
 	public function setUserAgent($ua)
 	{


### PR DESCRIPTION
[MediaWiki etiquette](https://www.mediawiki.org/wiki/API:Etiquette#The_User-Agent_header) prescribes the user agent string to include "client/version", where Wikimate used a space instead of the slash. This PR addresses that and adds reference links to the property and methods.