### PR TITLE
Add method Wikimate::logout()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 #### Added
 
 * New methods `WikiFile::revert()` and `Wikimate::filerevert()` ([#123])
+* New method `Wikimate::logout()` ([#124])
 
 #### Changed
 
@@ -151,3 +152,4 @@ Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/) 
 [#121]: https://github.com/hamstar/Wikimate/pull/121
 [#122]: https://github.com/hamstar/Wikimate/pull/122
 [#123]: https://github.com/hamstar/Wikimate/pull/123
+[#124]: https://github.com/hamstar/Wikimate/pull/124

--- a/USAGE.md
+++ b/USAGE.md
@@ -341,7 +341,7 @@ Both methods return an array of the MediaWiki API result.
 API requests are made over HTTP with a user agent string to identify
 the client to the server. By default the user agent is formatted as:
 
-`Wikimate <VERSION> (https://github.com/hamstar/Wikimate)`
+`Wikimate/<VERSION> (https://github.com/hamstar/Wikimate)`
 
 The string can be retrieved and customized via:
 
@@ -363,7 +363,8 @@ print_r($page->getError());
 ```
 
 For MediaWiki API errors, the array contains the 'code' and 'info' key/value pairs [defined by the API](https://www.mediawiki.org/wiki/Special:MyLanguage/API:Errors_and_warnings#Errors).  For other errors, the following key/value pairs are returned:
-* 'login' for Wikimate authentication problems
+* 'login' for Wikimate authentication problems <!-- TODO: remove after changing login() to use the 'auth' code too -->
+* 'auth' for Wikimate authentication problems
 * 'token' for Wikimate token problems
 * 'page' for WikiPage errors
 * 'file' for WikiFile errors


### PR DESCRIPTION
Covers the API [action Logout](https://www.mediawiki.org/wiki/Special:MyLanguage/API:Logout) and discards CSRF token (per #115).

The error code value is 'auth' because it doesn't make much sense to define a code 'logout' that's unlikely ever checked. Instead it would be logical to change the 'login' code into 'auth' as well (possibly also useful for #87 and #89), but that would be an small API-breaking change (similar to #116), so has to be delayed til v1.0.0. Hence the 'auth' entry is added to USAGE.md but the 'login' entry not yet removed.

A logout() example in USAGE.md would be too trivial so I didn't bother.
USAGE.md also includes a user agent fix I missed in #121.