### PR TITLE
Edit the README to add additional context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
+Wikimate is a PHP wrapper for the
+[MediaWiki Action API](https://www.mediawiki.org/wiki/Special:MyLanguage/API:Main_page)
+that aims to be very easy to use.
 It currently consists of three classes:
 
 * **Wikimate** – Serves as a loader and manager for different wiki objects (e.g. pages).
@@ -18,7 +20,7 @@ you will need to have PHP installed to run it. Install it with your preferred
 package management tool (for example, on Ubuntu Linux you can run:
 `sudo apt-get install php`)
 
-Install Composer by following the instructions at https://getcomposer.org/doc/00-intro.md
+Install Composer by following the instructions [here](https://getcomposer.org/doc/00-intro.md).
 
 Then, download Wikimate, and initialise it by running `composer install` (or
 `composer.bat install` if you're on Windows).
@@ -30,10 +32,10 @@ by adding the following to your `composer.json` file:
 
 ## Usage
 
-In your script file (e.g. `index.php`), include the `globals.php` file,
+In your script file (e.g. `index.php`), include Wikimate's `globals.php` file,
 and create a new `Wikimate` object with the target wiki's API address.
 Then provide a username and password to Wikimate's `login` method,
-to login to that wiki.
+to log in to that wiki.
 
 ```php
 include 'globals.php';
@@ -61,7 +63,7 @@ Instead of using echo statements, you can enable/disable debugging
 with the `$wiki->debugMode($boolean)` method.
 Currently only output from the logon process is printed for debugging.
 
-Assuming you were able to login, you're now ready to fully use the API.
+Assuming you were able to log in, you're now ready to fully use the API.
 
 See [USAGE.md](USAGE.md) for detailed example code to perform common tasks.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,10 +17,10 @@
 
 ### Introduction
 
-In your script file (e.g. `index.php`), include the `globals.php` file,
+In your script file (e.g. `index.php`), include Wikimate's `globals.php` file,
 and create a new `Wikimate` object with the target wiki's API address.
 Then provide a username and password to Wikimate's `login` method,
-to login to that wiki.
+to log in to that wiki.
 
 ```php
 include 'globals.php';
@@ -48,7 +48,7 @@ Instead of using echo statements, you can enable/disable debugging
 with the `$wiki->debugMode($boolean)` method.
 Currently only output from the logon process is printed for debugging.
 
-Assuming you were able to login, you're now ready to fully use the API.
+Assuming you were able to log in, you're now ready to fully use the API.
 The next sections provide example code for several common tasks.
 
 ### Getting a page object


### PR DESCRIPTION
Also fix "login" → "log in", and alias the Composer installation instructions link.