### PR TITLE
Remove deprecated method Wikimate::debugCurlConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 ### Upcoming version
 
-No changes yet.
+#### Removed
+
+* Method `Wikimate::debugCurlConfig()`, deprecated since v0.10.0 ([#128])
 
 ### Version 0.15.0 - 2021-08-26
 
@@ -160,3 +162,4 @@ No changes yet.
 [#123]: https://github.com/hamstar/Wikimate/pull/123
 [#124]: https://github.com/hamstar/Wikimate/pull/124
 [#125]: https://github.com/hamstar/Wikimate/pull/125
+[#128]: https://github.com/hamstar/Wikimate/pull/128

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -515,9 +515,9 @@ class Wikimate
 	/**
 	 * Gets or prints the Requests configuration.
 	 *
-	 * @param   boolean  $echo  Whether to echo the options
-	 * @return  array           Options if $echo is false
-	 * @return  boolean         True if options have been echoed to STDOUT
+	 * @param   boolean  $echo  Whether to echo the session options and headers
+	 * @return  mixed           Options array if $echo is false, or
+	 *                          True if options/headers have been echoed to STDOUT
 	 */
 	public function debugRequestsConfig($echo = false)
 	{


### PR DESCRIPTION
This method can be left behind at the v1.0 release.

Also fixes PHPDoc problem with two return tags for Wikimate::debugRequestsConfig().