### PR TITLE
Change error return values in WikiPage::getSection() and setText() (fixes #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and may require changes in applications that invoke these methods:_
 
 * Error return values for `WikiPage::getSection()` changed from `false` to `null` ([#129])
 
+#### Fixed
+
+* Fixed one error return value in `WikiPage::setText()` ([#129])
+
 #### Removed
 
 * Method `Wikimate::debugCurlConfig()`, deprecated since v0.10.0 ([#128])

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -1308,7 +1308,7 @@ class WikiPage
 			// Check for errors
 			if (isset($r['error'])) {
 				$this->error = $r['error']; // Set the error if there was one
-				return null;
+				return false;
 			} else {
 				$this->error = null; // Reset the error status
 			}


### PR DESCRIPTION
See issue #116.