### PR TITLE
Fix exception message for keyNames parameter to WikiPage::getAllSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and may require changes in applications that invoke these methods:_
 #### Fixed
 
 * Fixed one error return value in `WikiPage::setText()` ([#129])
+* Fixed exception type/message for `$keyNames` parameter to `WikiPage::getAllSections()` ([#133])
 
 #### Removed
 
@@ -184,3 +185,4 @@ and may require changes in applications that invoke these methods:_
 [#130]: https://github.com/hamstar/Wikimate/pull/130
 [#131]: https://github.com/hamstar/Wikimate/pull/131
 [#132]: https://github.com/hamstar/Wikimate/pull/132
+[#133]: https://github.com/hamstar/Wikimate/pull/133

--- a/USAGE.md
+++ b/USAGE.md
@@ -127,7 +127,7 @@ Array
 )
 ```
 
-An Exception is thrown if an unsupported value is supplied for the $keyNames parameter.
+An `UnexpectedValueException` is thrown if an unsupported value is supplied for the `$keyNames` parameter.
 
 #### Writing...
 

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -891,7 +891,7 @@ class WikiPage
 	{
 		$this->wikimate = $wikimate;
 		$this->title    = $title;
-		$this->sections = new stdClass();
+		$this->sections = new \stdClass();
 		$this->text     = $this->getText(true);
 
 		if ($this->invalid) {
@@ -1206,7 +1206,7 @@ class WikiPage
 	 * @param   boolean  $includeHeading  False to get section text only
 	 * @param   integer  $keyNames        Modifier for the array key names
 	 * @return  array                     Array of sections
-	 * @throw   Exception                 If $keyNames is not a supported constant
+	 * @throw   UnexpectedValueException  If $keyNames is not a supported constant
 	 */
 	public function getAllSections($includeHeading = false, $keyNames = self::SECTIONLIST_BY_INDEX)
 	{
@@ -1220,7 +1220,7 @@ class WikiPage
 				$array = array_keys($this->sections->byName);
 				break;
 			default:
-				throw new Exception('Unexpected parameter $keyNames given to WikiPage::getAllSections()');
+				throw new \UnexpectedValueException("Unexpected keyNames parameter ($keyNames) passed to WikiPage::getAllSections()");
 				break;
 		}
 


### PR DESCRIPTION
While reviewing the exception/error handling situation this one jumped out just now. The single quotes meant that $keyNames was shown verbatim, not its value. Now the message clarifies which parameter has what unexpected value.

The exception type is also changed to the more specific and appropriate [UnexpectedValueException](https://www.php.net/manual/en/class.unexpectedvalueexception.php).