### PR TITLE
Add usage documentation about maximum lag and retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 ### Upcoming version
 
+#### Added
+
+* Usage documentation about maximum lag and retries ([#134])
+
 #### Changed
 
 * Added additional context to README.md ([#127])
@@ -186,3 +190,4 @@ and may require changes in applications that invoke these methods:_
 [#131]: https://github.com/hamstar/Wikimate/pull/131
 [#132]: https://github.com/hamstar/Wikimate/pull/132
 [#133]: https://github.com/hamstar/Wikimate/pull/133
+[#134]: https://github.com/hamstar/Wikimate/pull/134

--- a/USAGE.md
+++ b/USAGE.md
@@ -13,6 +13,7 @@
 - [Other stuff](#other-stuff)
   * [Running custom queries](#running-custom-queries)
   * [Customizing the user agent](#customizing-the-user-agent)
+  * [Maximum lag and retries](#maximum-lag-and-retries)
   * [Handling errors](#handling-errors)
 
 ### Introduction
@@ -353,6 +354,18 @@ $wiki->setUserAgent('Custom Prefix - ' . $useragent);
 
 In order to use a custom user agent for all requests in the session,
 call this method before invoking `Wikimate::login()`.
+
+#### Maximum lag and retries
+
+API requests include the [maxlag parameter](https://www.mediawiki.org/wiki/Special:MyLanguage/Manual:Maxlag_parameter)
+so they time out when the server's time to respond exceeds the specified lag.
+The default lag is 5 seconds, which can be obtained via `$wiki->getMaxlag()`
+and changed via `$wiki->setMaxlag()`.
+Upon a lag error response,
+the request is [paused](https://www.php.net/manual/en/function.sleep)
+for the number of seconds recommended by the server, and then retried.
+Retries continue indefinitely, unless limited via `$wiki->setMaxretries()`.
+If a limited number of retries runs out, `WikimateException` is thrown.
 
 #### Handling errors
 


### PR DESCRIPTION
In all the work and discussion regarding #112, I took a shortcut in not documenting the feature, and my trusty reviewer didn't remind me about it either. :wink: 

The text already uses `WikimateException` which doesn't exist yet, but will be defined in my next PR (after this and #133 are merged).