### PR TITLE
Add WikimateException and centralize API error checks in request() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 #### Added
 
+* New exception class `WikimateException` for API communication errors ([#136])
 * Usage documentation about maximum lag and retries ([#134])
 * New `CONTRIBUTING.md` file with contribution guidelines ([#135])
 
 #### Changed
 
+* Centralized API communication checks in `WikiPage::request()` ([#136])
 * Added additional context to `README.md` ([#127])
 * Added semi-linear merge recommendation to `GOVERNANCE.md` ([#130])
 * Added GitHub Action to enforce updates to `CHANGELOG.md` ([#131])
@@ -204,3 +206,4 @@ and may require changes in applications that invoke these methods:_
 [#133]: https://github.com/hamstar/Wikimate/pull/133
 [#134]: https://github.com/hamstar/Wikimate/pull/134
 [#135]: https://github.com/hamstar/Wikimate/pull/135
+[#136]: https://github.com/hamstar/Wikimate/pull/136

--- a/USAGE.md
+++ b/USAGE.md
@@ -14,7 +14,7 @@
   * [Running custom queries](#running-custom-queries)
   * [Customizing the user agent](#customizing-the-user-agent)
   * [Maximum lag and retries](#maximum-lag-and-retries)
-  * [Handling errors](#handling-errors)
+  * [Handling errors and exceptions](#handling-errors-and-exceptions)
 
 ### Introduction
 
@@ -380,7 +380,7 @@ for the number of seconds recommended by the server, and then retried.
 Retries continue indefinitely, unless limited via `$wiki->setMaxretries()`.
 If a limited number of retries runs out, `WikimateException` is thrown.
 
-#### Handling errors
+#### Handling errors and exceptions
 
 Did something go wrong?  Check the error array:
 
@@ -396,3 +396,7 @@ For other errors, the following key/value pairs are returned:
 * 'token' for Wikimate token problems
 * 'page' for WikiPage errors
 * 'file' for WikiFile errors
+
+In case of an unexpected error while communicating with the API,
+i.e. receiving an HTML response or an invalid JSON response,
+or running out of maxlag retries, `WikimateException` is thrown.

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -10,7 +10,7 @@
 /**
  * Provides an interface over wiki API objects such as pages and files.
  *
- * All requests to the API can throw an exception if the server is lagged
+ * All requests to the API can throw WikimateException if the server is lagged
  * and a finite number of retries is exhausted.  By default requests are
  * retried indefinitely.  See {@see Wikimate::request()} for more information.
  *
@@ -174,7 +174,7 @@ class Wikimate
 	 * If a lag error is received, the method waits (sleeps) for the
 	 * recommended time (per the Retry-After header), then tries again.
 	 * It will do this indefinitely unless the number of retries is limited,
-	 * in which case an exception is thrown once the limit is reached.
+	 * in which case WikimateException is thrown once the limit is reached.
 	 *
 	 * The string type for $data is used only for upload POST requests,
 	 * and must contain the complete multipart body, including maxlag.
@@ -183,7 +183,7 @@ class Wikimate
 	 * @param  array         $headers  Optional extra headers to send with the request
 	 * @param  boolean       $post     True to send a POST request, otherwise GET
 	 * @return Requests_Response       The API response
-	 * @throw  Exception               If lagged and ran out of retries
+	 * @throw  WikimateException       If lagged and ran out of retries
 	 */
 	private function request($data, $headers = array(), $post = false)
 	{
@@ -230,7 +230,7 @@ class Wikimate
 
 		// Throw exception if we ran out of retries
 		if ($server_lagged) {
-			throw new Exception("Server lagged ($retries consecutive maxlag responses)");
+			throw new WikimateException("Server lagged ($retries consecutive maxlag responses)");
 		} else {
 			return $response;
 		}
@@ -794,6 +794,19 @@ class Wikimate
 		return $this->error;
 	}
 }
+
+
+/**
+ * Defines Wikimate's exception for unexpected run-time errors
+ * while communicating with the API.
+ * WikimateException can be thrown only from Wikimate::request(),
+ * and is propagated to callers of this library.
+ *
+ * @author  Frans P. de Vries
+ * @since   1.0.0  August 2021
+ * @link    https://www.php.net/manual/en/class.runtimeexception.php
+ */
+class WikimateException extends RuntimeException {}
 
 
 /**

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -183,7 +183,8 @@ class Wikimate
 	 * @param  array         $headers  Optional extra headers to send with the request
 	 * @param  boolean       $post     True to send a POST request, otherwise GET
 	 * @return Requests_Response       The API response
-	 * @throw  WikimateException       If lagged and ran out of retries
+	 * @throw  WikimateException       If lagged and ran out of retries,
+	 *                                 or got an unexpected API response
 	 */
 	private function request($data, $headers = array(), $post = false)
 	{
@@ -193,7 +194,12 @@ class Wikimate
 		if (is_array($data)) {
 			$data['format'] = 'json';
 			$data['maxlag'] = $this->getMaxlag();
+			$action = $data['action'];
+		} else {
+			$action = 'upload';
 		}
+		// Define type of HTTP request for messages
+		$httptype = $post ? 'POST' : 'GET';
 
 		// Send appropriate type of request, once or multiple times
 		do {
@@ -231,9 +237,20 @@ class Wikimate
 		// Throw exception if we ran out of retries
 		if ($server_lagged) {
 			throw new WikimateException("Server lagged ($retries consecutive maxlag responses)");
-		} else {
-			return $response;
 		}
+
+		// Check if we got the API doc page (invalid request)
+		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
+			throw new WikimateException("The API could not understand the $action $httptype request");
+		}
+
+		// Check if we got a JSON result
+		$result = json_decode($response->body, true);
+		if ($result === null) {
+			throw new WikimateException("The API did not return the $action JSON response");
+		}
+
+		return $response;
 	}
 
 	/**
@@ -275,20 +292,7 @@ class Wikimate
 		// Send the token request
 		$response = $this->request($details, array(), true);
 
-		// Check if we got an API result or the API doc page (invalid request)
-		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
-			$this->error = array();
-			$this->error['token'] = 'The API could not understand the token request';
-			return null;
-		}
-
 		$tokenResult = json_decode($response->body, true);
-		// Check if we got a JSON result
-		if ($tokenResult === null) {
-			$this->error = array();
-			$this->error['token'] = 'The API did not return the token response';
-			return null;
-		}
 
 		if ($this->debugMode) {
 			echo "Token request:\n";
@@ -337,20 +341,7 @@ class Wikimate
 		// Send the login request
 		$response = $this->request($details, array(), true);
 
-		// Check if we got an API result or the API doc page (invalid request)
-		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
-			$this->error = array();
-			$this->error['auth'] = 'The API could not understand the login request';
-			return false;
-		}
-
 		$loginResult = json_decode($response->body, true);
-		// Check if we got a JSON result
-		if ($loginResult === null) {
-			$this->error = array();
-			$this->error['auth'] = 'The API did not return the login response';
-			return false;
-		}
 
 		if ($this->debugMode) {
 			echo "Login request:\n";
@@ -399,20 +390,7 @@ class Wikimate
 		// Send the logout request
 		$response = $this->request($details, array(), true);
 
-		// Check if we got an API result or the API doc page (invalid request)
-		if (strpos($response->body, "This is an auto-generated MediaWiki API documentation page") !== false) {
-			$this->error = array();
-			$this->error['auth'] = 'The API could not understand the logout request';
-			return false;
-		}
-
 		$logoutResult = json_decode($response->body, true);
-		// Check if we got a JSON result
-		if ($logoutResult === null) {
-			$this->error = array();
-			$this->error['auth'] = 'The API did not return the logout response';
-			return false;
-		}
 
 		if ($this->debugMode) {
 			echo "Logout request:\n";


### PR DESCRIPTION
This implements the exception handling portion of #113, where the reasoning for this approach is discussed. Debug logging changes will go into a separate PR, which will close that issue.

A commit with documentation/changelog edits follows after #135 is wrapped up and merged. (Hmm, I guess this should have been a draft PR. Can it still be changed?)