### PR TITLE
Centralize API debug logging in Wikimate::request() (fixes #113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 - Centralized API communication checks in `WikiPage::request()` ([#136])
+- Centralized debug logging of API requests/responses in `WikiPage::request()` ([#139])
 - Added additional context to `README.md` ([#127])
 - Added semi-linear merge recommendation to `GOVERNANCE.md` ([#130])
 
@@ -211,3 +212,4 @@ and may require changes in applications that invoke these methods:_
 [#135]: https://github.com/hamstar/Wikimate/pull/135
 [#136]: https://github.com/hamstar/Wikimate/pull/136
 [#138]: https://github.com/hamstar/Wikimate/pull/138
+[#139]: https://github.com/hamstar/Wikimate/pull/139

--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ else {
 
 This example uses echo statements to output any potential errors.
 You should get a meaningful error message if the authentication fails.
-
-Instead of using echo statements, you can enable/disable debugging
-with the `$wiki->debugMode($boolean)` method.
-Currently only output from the logon process is printed for debugging.
-
 Assuming you were able to log in, you're now ready to fully use the API.
 
 See [USAGE.md](USAGE.md) for detailed example code to perform common tasks.

--- a/USAGE.md
+++ b/USAGE.md
@@ -15,6 +15,7 @@
   - [Customizing the user agent](#customizing-the-user-agent)
   - [Maximum lag and retries](#maximum-lag-and-retries)
   - [Handling errors and exceptions](#handling-errors-and-exceptions)
+  - [Debug logging](#debug-logging)
 
 ## Introduction
 
@@ -44,10 +45,6 @@ else {
 
 This example uses echo statements to output any potential errors.
 You should get a meaningful error message if the authentication fails.
-
-Instead of using echo statements, you can enable/disable debugging
-with the `$wiki->debugMode($boolean)` method.
-Currently only output from the logon process is printed for debugging.
 
 Assuming you were able to log in, you're now ready to fully use the API.
 The next sections provide example code for several common tasks.
@@ -401,3 +398,13 @@ For other errors, the following key/value pairs are returned:
 In case of an unexpected error while communicating with the API,
 i.e. receiving an HTML response or an invalid JSON response,
 or running out of maxlag retries, `WikimateException` is thrown.
+
+### Debug logging
+
+In addition to checking the error array,
+you can enable/disable debugging with the `$wiki->debugMode($boolean)` method.
+Debug logging is printed to [standard output](https://en.wikipedia.org/wiki/Standard_output)
+and includes API requests/responses as well as retry messages for [lag errors](#maximum-lag-and-retries).
+
+Only requests for file uploads are not logged,
+because of the (potential) volume of the associated data.

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -307,6 +307,14 @@ class Wikimate
 		// Send the token request
 		$tokenResult = $this->request($details, array(), true);
 
+		// Check for errors
+		if (isset($tokenResult['error'])) {
+			$this->error = $tokenResult['error']; // Set the error if there was one
+			return null;
+		} else {
+			$this->error = null; // Reset the error status
+		}
+
 		if ($type == self::TOKEN_LOGIN) {
 			return $tokenResult['query']['tokens']['logintoken'];
 		} else {
@@ -347,6 +355,14 @@ class Wikimate
 		// Send the login request
 		$loginResult = $this->request($details, array(), true);
 
+		// Check for errors
+		if (isset($loginResult['error'])) {
+			$this->error = $loginResult['error']; // Set the error if there was one
+			return false;
+		} else {
+			$this->error = null; // Reset the error status
+		}
+
 		if (isset($loginResult['login']['result']) && $loginResult['login']['result'] != 'Success') {
 			// Some more comprehensive error checking
 			$this->error = array();
@@ -386,6 +402,14 @@ class Wikimate
 
 		// Send the logout request
 		$logoutResult = $this->request($details, array(), true);
+
+		// Check for errors
+		if (isset($logoutResult['error'])) {
+			$this->error = $logoutResult['error']; // Set the error if there was one
+			return false;
+		} else {
+			$this->error = null; // Reset the error status
+		}
 
 		// Discard CSRF token for this login session
 		$this->csrf_token = null;

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -182,7 +182,7 @@ class Wikimate
 	 * @param  array|string  $data     Data for the request
 	 * @param  array         $headers  Optional extra headers to send with the request
 	 * @param  boolean       $post     True to send a POST request, otherwise GET
-	 * @return Requests_Response       The API response
+	 * @return array                   The API response
 	 * @throw  WikimateException       If lagged and ran out of retries,
 	 *                                 or got an unexpected API response
 	 */
@@ -265,7 +265,7 @@ class Wikimate
 			print_r($result);
 		}
 
-		return $response;
+		return $result;
 	}
 
 	/**
@@ -305,16 +305,7 @@ class Wikimate
 		);
 
 		// Send the token request
-		$response = $this->request($details, array(), true);
-
-		$tokenResult = json_decode($response->body, true);
-
-		if ($this->debugMode) {
-			echo "Token request:\n";
-			print_r($details);
-			echo "Token response:\n";
-			print_r($tokenResult);
-		}
+		$tokenResult = $this->request($details, array(), true);
 
 		if ($type == self::TOKEN_LOGIN) {
 			return $tokenResult['query']['tokens']['logintoken'];
@@ -354,16 +345,7 @@ class Wikimate
 		}
 
 		// Send the login request
-		$response = $this->request($details, array(), true);
-
-		$loginResult = json_decode($response->body, true);
-
-		if ($this->debugMode) {
-			echo "Login request:\n";
-			print_r($details);
-			echo "Login response:\n";
-			print_r($loginResult);
-		}
+		$loginResult = $this->request($details, array(), true);
 
 		if (isset($loginResult['login']['result']) && $loginResult['login']['result'] != 'Success') {
 			// Some more comprehensive error checking
@@ -403,16 +385,7 @@ class Wikimate
 		);
 
 		// Send the logout request
-		$response = $this->request($details, array(), true);
-
-		$logoutResult = json_decode($response->body, true);
-
-		if ($this->debugMode) {
-			echo "Logout request:\n";
-			print_r($details);
-			echo "Logout response:\n";
-			print_r($logoutResult);
-		}
+		$logoutResult = $this->request($details, array(), true);
 
 		// Discard CSRF token for this login session
 		$this->csrf_token = null;
@@ -558,17 +531,7 @@ class Wikimate
 	{
 		$array['action'] = 'query';
 
-		if ($this->debugMode) {
-			echo "query GET parameters:\n";
-			echo http_build_query($array) . "\n";
-		}
-		$apiResult = $this->request($array);
-
-		if ($this->debugMode) {
-			echo "query GET response:\n";
-			print_r(json_decode($apiResult->body, true));
-		}
-		return json_decode($apiResult->body, true);
+		return $this->request($array);
 	}
 
 	/**
@@ -582,17 +545,7 @@ class Wikimate
 	{
 		$array['action'] = 'parse';
 
-		if ($this->debugMode) {
-			echo "parse GET parameters:\n";
-			echo http_build_query($array) . "\n";
-		}
-		$apiResult = $this->request($array);
-
-		if ($this->debugMode) {
-			echo "parse GET response:\n";
-			print_r(json_decode($apiResult->body, true));
-		}
-		return json_decode($apiResult->body, true);
+		return $this->request($array);
 	}
 
 	/**
@@ -616,17 +569,7 @@ class Wikimate
 		$array['action'] = 'edit';
 		$array['token'] = $edittoken;
 
-		if ($this->debugMode) {
-			echo "edit POST parameters:\n";
-			print_r($array);
-		}
-		$apiResult = $this->request($array, $headers, true);
-
-		if ($this->debugMode) {
-			echo "edit POST response:\n";
-			print_r(json_decode($apiResult->body, true));
-		}
-		return json_decode($apiResult->body, true);
+		return $this->request($array, $headers, true);
 	}
 
 	/**
@@ -650,17 +593,7 @@ class Wikimate
 		$array['action'] = 'delete';
 		$array['token'] = $deletetoken;
 
-		if ($this->debugMode) {
-			echo "delete POST parameters:\n";
-			print_r($array);
-		}
-		$apiResult = $this->request($array, $headers, true);
-
-		if ($this->debugMode) {
-			echo "delete POST response:\n";
-			print_r(json_decode($apiResult->body, true));
-		}
-		return json_decode($apiResult->body, true);
+		return $this->request($array, $headers, true);
 	}
 
 	/**
@@ -735,13 +668,7 @@ class Wikimate
 			'Content-Length' => strlen($body),
 		);
 
-		$apiResult = $this->request($body, $headers, true);
-
-		if ($this->debugMode) {
-			echo "upload POST response:\n";
-			print_r(json_decode($apiResult->body, true));
-		}
-		return json_decode($apiResult->body, true);
+		return $this->request($body, $headers, true);
 	}
 
 	/**
@@ -765,17 +692,7 @@ class Wikimate
 			'Content-Type' => "application/x-www-form-urlencoded"
 		);
 
-		if ($this->debugMode) {
-			echo "filerevert POST parameters:\n";
-			echo http_build_query($array) . "\n";
-		}
-		$apiResult = $this->request($array, $headers, true);
-
-		if ($this->debugMode) {
-			echo "filerevert POST response:\n";
-			print_r(json_decode($apiResult->body, true));
-		}
-		return json_decode($apiResult->body, true);
+		return $this->request($array, $headers, true);
 	}
 
 	/**

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -204,8 +204,18 @@ class Wikimate
 		// Send appropriate type of request, once or multiple times
 		do {
 			if ($post) {
+				// Debug logging of POST requests, except for upload string
+				if ($this->debugMode && is_array($data)) {
+					echo "$action $httptype parameters:\n";
+					print_r($data);
+				}
 				$response = $this->session->post($this->api, $headers, $data);
 			} else {
+				// Debug logging of GET requests as a query string
+				if ($this->debugMode) {
+					echo "$action $httptype parameters:\n";
+					echo http_build_query($data) . "\n";
+				}
 				$response = $this->session->get($this->api.'?'.http_build_query($data), $headers);
 			}
 
@@ -248,6 +258,11 @@ class Wikimate
 		$result = json_decode($response->body, true);
 		if ($result === null) {
 			throw new WikimateException("The API did not return the $action JSON response");
+		}
+
+		if ($this->debugMode) {
+			echo "$action $httptype response:\n";
+			print_r($result);
 		}
 
 		return $response;
@@ -659,6 +674,7 @@ class Wikimate
 		$getResult = $this->session->get($url);
 
 		if (!$getResult->success) {
+			// Debug logging of Requests_Response only on failed download
 			if ($this->debugMode) {
 				echo "download GET response:\n";
 				print_r($getResult);


### PR DESCRIPTION
See discussion in issue #113. This is the "other half" of the centralization steps started with #136. Combined they reduce the overall length of `Wikimake.php` by some 50 lines, and significantly streamline all methods that call `request()`.
