### PR TITLE
Prepare for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 ## Upcoming version
 
+No changes yet.
+
+## Version 1.0.0 - 2021-09-05
+
 ### Added
 
 - New exception class `WikimateException` for API communication errors ([#136])

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It currently consists of three classes:
 - **WikiFile** – Provides an interface to downloading/uploading files and getting their properties.
 
 The [latest released version](https://github.com/hamstar/Wikimate/releases) of Wikimate
-is v0.15.0, released on Aug 26, 2021.
+is v1.0.0, released on September 5, 2021.
 It requires MediaWiki v1.27 or newer.
 See [CHANGELOG.md](CHANGELOG.md) for the detailed version history.
 
@@ -45,7 +45,7 @@ by adding the following to your existing `composer.json` file:
 ```json
 {
     "require": {
-        "hamstar/Wikimate": "^0.15"
+        "hamstar/Wikimate": "^1.0"
     }
 }
 ```

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -3,7 +3,7 @@
  * Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
  *
  * @package    Wikimate
- * @version    0.15.0
+ * @version    1.0.0
  * @copyright  SPDX-License-Identifier: MIT
  */
 
@@ -25,7 +25,7 @@ class Wikimate
 	 * @var string
 	 * @link https://semver.org/
 	 */
-	const VERSION = '0.15.0';
+	const VERSION = '1.0.0';
 
 	/**
 	 * Identifier for CSRF token


### PR DESCRIPTION
Release summary:

This release completes Wikimate's initial development phase and:
- makes two small backwards incompatible changes to error handling in the API;
- removes the `globals.php` file in lieu of Composer's regular autoloading;
- adds the new WikimateException class for API communication errors;
- centralizes API communication checks and debug logging; and
- adds contribution guidelines and makes numerous other documentation improvements.

It requires MediaWiki v1.27 or newer. For more details on these changes, including links to the corresponding pull requests, please check the Changelog.
