### PR TITLE
Resolve static analysis warnings reported by PHPStan & PHPMD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
-- Applied code formatting rules from [PSR](https://www.php-fig.org/psr/) 2 and 12 ([#142])
+- Applied code formatting rules from [PSR-12](https://www.php-fig.org/psr/psr-12/) ([#142])
+- Resolved static analysis warnings reported by [PHPStan](https://phpstan.org/) &
+  [PHPMD](https://phpmd.org/) ([#143])
 
 ## Version 1.0.0 - 2021-09-05
 
@@ -223,3 +225,4 @@ and may require changes in applications that invoke these methods:_
 [#139]: https://github.com/hamstar/Wikimate/pull/139
 [#140]: https://github.com/hamstar/Wikimate/pull/140
 [#142]: https://github.com/hamstar/Wikimate/pull/142
+[#143]: https://github.com/hamstar/Wikimate/pull/143

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -61,6 +61,27 @@ class Wikimate
     protected $api;
 
     /**
+     * Default headers for Requests_Session
+     *
+     * @var array
+     */
+    protected $headers;
+
+    /**
+     * Default data for Requests_Session
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Default options for Requests_Session
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
      * Username for API requests
      *
      * @var string
@@ -576,8 +597,8 @@ class Wikimate
     /**
      * Perfoms an edit query to the wiki API.
      *
-     * @param   array  $array  Array of details to be passed in the query
-     * @return  array          Decoded JSON output from the wiki API
+     * @param   array         $array  Array of details to be passed in the query
+     * @return  array|boolean         Decoded JSON output from the wiki API
      * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Edit
      */
     public function edit($array)
@@ -600,8 +621,8 @@ class Wikimate
     /**
      * Perfoms a delete query to the wiki API.
      *
-     * @param   array  $array  Array of details to be passed in the query
-     * @return  array          Decoded JSON output from the wiki API
+     * @param   array          $array  Array of details to be passed in the query
+     * @return  array|boolean          Decoded JSON output from the wiki API
      * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Delete
      */
     public function delete($array)
@@ -648,8 +669,8 @@ class Wikimate
     /**
      * Uploads a file to the wiki API.
      *
-     * @param   array    $array  Array of details to be used in the upload
-     * @return  array            Decoded JSON output from the wiki API
+     * @param   array            $array  Array of details to be used in the upload
+     * @return  array|boolean            Decoded JSON output from the wiki API
      * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Upload
      */
     public function upload($array)
@@ -699,8 +720,8 @@ class Wikimate
     /**
      * Performs a file revert query to the wiki API.
      *
-     * @param   array  $array  Array of details to be passed in the query
-     * @return  array          Decoded JSON output from the wiki API
+     * @param   array          $array  Array of details to be passed in the query
+     * @return  array|boolean          Decoded JSON output from the wiki API
      * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Filerevert
      */
     public function filerevert($array)
@@ -903,6 +924,8 @@ class WikiPage
 
     /**
      * Alias of self::__destruct().
+     *
+     * @return void
      */
     public function destroy()
     {
@@ -1111,6 +1134,8 @@ class WikiPage
                 return null;
             }
             $coords = $this->sections->byName[$section];
+        } else {
+            $coords = array();
         }
 
         // Extract the offset, depth and (initial) length
@@ -1172,7 +1197,6 @@ class WikiPage
             default:
                 throw new \UnexpectedValueException("Unexpected keyNames parameter " .
                     "($keyNames) passed to WikiPage::getAllSections()");
-                break;
         }
 
         foreach ($array as $key) {
@@ -1492,6 +1516,8 @@ class WikiFile
 
     /**
      * Alias of self::__destruct().
+     *
+     * @return void
      */
     public function destroy()
     {

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -150,7 +150,7 @@ class Wikimate
      * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Tokens
      * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Edit#Additional_notes
      */
-    private $csrf_token = null;
+    private $csrfToken = null;
 
     /**
      * Creates a new Wikimate object.
@@ -242,8 +242,8 @@ class Wikimate
             }
 
             // Check for replication lag error
-            $server_lagged = ($response->headers->offsetGet('X-Database-Lag') !== null);
-            if ($server_lagged) {
+            $serverLagged = ($response->headers->offsetGet('X-Database-Lag') !== null);
+            if ($serverLagged) {
                 // Determine recommended or default delay
                 if ($response->headers->offsetGet('Retry-After') !== null) {
                     $sleep = (int)$response->headers->offsetGet('Retry-After');
@@ -264,10 +264,10 @@ class Wikimate
                     $retries = -1; // continue indefinitely
                 }
             }
-        } while ($server_lagged && $retries <= $this->getMaxretries());
+        } while ($serverLagged && $retries <= $this->getMaxretries());
 
         // Throw exception if we ran out of retries
-        if ($server_lagged) {
+        if ($serverLagged) {
             throw new WikimateException("Server lagged ($retries consecutive maxlag responses)");
         }
 
@@ -316,8 +316,8 @@ class Wikimate
         }
 
         // Check for existing CSRF token for this login session
-        if ($type == self::TOKEN_DEFAULT && $this->csrf_token !== null) {
-            return $this->csrf_token;
+        if ($type == self::TOKEN_DEFAULT && $this->csrfToken !== null) {
+            return $this->csrfToken;
         }
 
         $details = array(
@@ -341,8 +341,8 @@ class Wikimate
             return $tokenResult['query']['tokens']['logintoken'];
         } else {
             // Store CSRF token for this login session
-            $this->csrf_token = $tokenResult['query']['tokens']['csrftoken'];
-            return $this->csrf_token;
+            $this->csrfToken = $tokenResult['query']['tokens']['csrftoken'];
+            return $this->csrfToken;
         }
     }
 
@@ -434,7 +434,7 @@ class Wikimate
         }
 
         // Discard CSRF token for this login session
-        $this->csrf_token = null;
+        $this->csrfToken = null;
         return true;
     }
 
@@ -1334,7 +1334,7 @@ class WikiPage
      */
     public function newSection($name, $text)
     {
-        return $this->setSection($text, $section = 'new', $summary = $name, $minor = false);
+        return $this->setSection($text, 'new', $name, false);
     }
 
     /**


### PR DESCRIPTION
[PHPStan](https://phpstan.org/) points out potential code problems via static analysis. Running `vendor/bin/phpstan analyse -c phpstan.neon` with this config file:
```
parameters:
	level: 6
	paths:
		- Wikimate.php
	checkMissingIterableValueType: false
```
listed the following warnings at [this level](https://phpstan.org/user-guide/rule-levels) (line numbers prior to the commit):
```
 ------ ---------------------------------------------------------------------- 
  Line   Wikimate.php                                                          
 ------ ---------------------------------------------------------------------- 
  146    Access to an undefined property Wikimate::$headers.                   
  147    Access to an undefined property Wikimate::$data.                      
  148    Access to an undefined property Wikimate::$options.                   
  164    Access to an undefined property Wikimate::$data.                      
  164    Access to an undefined property Wikimate::$headers.                   
  164    Access to an undefined property Wikimate::$options.                   
  587    Method Wikimate::edit() should return array but returns false.        
  611    Method Wikimate::delete() should return array but returns false.      
  659    Method Wikimate::upload() should return array but returns false.      
  710    Method Wikimate::filerevert() should return array but returns false.  
  907    Method WikiPage::destroy() has no return typehint specified.          
  1175   Unreachable statement - code above always terminates.                 
  1496   Method WikiFile::destroy() has no return typehint specified.          
 ------ ---------------------------------------------------------------------- 
```
The first commit addresses all these, little point in splitting them up.

The `checkMissingIterableValueType` config flag disables a [frequent warning](https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type) I don't want to bother with.

A handful more warnings remain (line numbers after the commit):
```
  186    Access to an undefined property Requests_Session::$useragent.  
  511    Access to an undefined property Requests_Session::$useragent.  
  1158   Variable $offset might not be defined.                         
  1163   Variable $depth might not be defined.                          
  1164   Variable $length might not be defined.                         
  1178   Variable $length might not be defined.                         
  1178   Variable $offset might not be defined.                         
  1181   Variable $offset might not be defined.      
```                   
The first pair cannot be resolved because the structure of the `$session` object returned by Requests_Session is unknown, and there is no setter method to replace the simple assignment.
The variable warnings are not worth the trouble at this time either, IMHO.