### PR TITLE
Clarify error response for edits denied by a CAPTCHA (fixes #144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and [Keep a Changelog](http://keepachangelog.com/).
 - Applied code formatting rules from [PSR-12](https://www.php-fig.org/psr/psr-12/) ([#142])
 - Resolved static analysis warnings reported by [PHPStan](https://phpstan.org/) &
   [PHPMD](https://phpmd.org/) ([#143])
+- Clarified error response for edits denied by a CAPTCHA ([#145])
 
 ## Version 1.0.0 - 2021-09-05
 
@@ -226,3 +227,4 @@ and may require changes in applications that invoke these methods:_
 [#140]: https://github.com/hamstar/Wikimate/pull/140
 [#142]: https://github.com/hamstar/Wikimate/pull/142
 [#143]: https://github.com/hamstar/Wikimate/pull/143
+[#145]: https://github.com/hamstar/Wikimate/pull/145

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -1297,7 +1297,11 @@ class WikiPage
             $this->error = $r['error'];
         } else {
             $this->error = array();
-            $this->error['page'] = 'Unexpected edit response: ' . $r['edit']['result'];
+            if (isset($r['edit']['captcha'])) {
+                $this->error['page'] = 'Edit denied by CAPTCHA';
+            } else {
+                $this->error['page'] = 'Unexpected edit response: ' . $r['edit']['result'];
+            }
         }
         return false;
     }


### PR DESCRIPTION
If the [ConfirmEdit extension](https://www.mediawiki.org/wiki/Extension:ConfirmEdit) is enabled with a Captcha module, this can block [five types of activity](https://www.mediawiki.org/wiki/Extension:ConfirmEdit#Configuration). The latter two (createaccount & badlogin) are not relevant to Wikimate, the former three (edit, create & addurl) can occur via `Wikimate::edit()` in `WikiPage::setText()`.

This PR sets an error message "Edit denied by CAPTCHA" for this situation, instead of the generic "Unexpected edit response".