### PR TITLE
Activate default markdownlint rules

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,11 @@
+# Default state for all rules
+default: true
+
+# MD004/ul-style
+MD004:
+  # Use dashes for lists, leaving asterisks for emphasis
+  style: "dash"
+
 # MD010/no-hard-tabs
 MD010:
   # Exclude code blocks
@@ -19,8 +27,3 @@ MD024:
 MD026:
   # Trailing punctuation characters not allowed in headings
   punctuation: ",;:!"
-
-# MD004/ul-style
-MD004:
-  # Use dashes for lists, leaving asterisks for emphasis
-  style: "dash"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and [Keep a Changelog](http://keepachangelog.com/).
 - Resolved static analysis warnings reported by [PHPStan](https://phpstan.org/) &
   [PHPMD](https://phpmd.org/) ([#143])
 - Clarified error response for edits denied by a CAPTCHA ([#145])
+- Activated default markdownlint rules ([#146])
 
 ## Version 1.0.0 - 2021-09-05
 
@@ -228,3 +229,4 @@ and may require changes in applications that invoke these methods:_
 [#142]: https://github.com/hamstar/Wikimate/pull/142
 [#143]: https://github.com/hamstar/Wikimate/pull/143
 [#145]: https://github.com/hamstar/Wikimate/pull/145
+[#146]: https://github.com/hamstar/Wikimate/pull/146


### PR DESCRIPTION
Also sort the rules by their number, to make it easier to locate them.

This was inspired by [commit `ce7efb2` from PR#145](https://github.com/hamstar/Wikimate/pull/145/commits/ce7efb24db43cfdca71d1150c2d1a8c7cb6ff054). The default value for markdownlint's [`MD049/emphasis-style` rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md049---emphasis-style-should-be-consistent) is "consistent", which would have caught the issue resolved in that commit.