### PR TITLE
Added internal mechanism to handle version-dependent parameters of API modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 ## Upcoming version
 
+### Added
+
+- Added internal mechanism to handle version-dependent parameters of API modules ([#151])
+
 ### Changed
 
 - Applied code formatting rules from [PSR-12](https://www.php-fig.org/psr/psr-12/) ([#142])
@@ -241,3 +245,4 @@ and may require changes in applications that invoke these methods:_
 [#148]: https://github.com/hamstar/Wikimate/pull/148
 [#149]: https://github.com/hamstar/Wikimate/pull/149
 [#150]: https://github.com/hamstar/Wikimate/pull/150
+[#151]: https://github.com/hamstar/Wikimate/pull/151

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -473,17 +473,18 @@ class Wikimate
      */
     public function logout()
     {
-        // Obtain logout token first
-        if (($logouttoken = $this->token()) === null) {
-            return false;
-        }
-
-        // Token is needed in MediaWiki v1.34+, older versions produce an
-        // 'Unrecognized parameter' warning which can be ignored
         $details = array(
             'action' => 'logout',
-            'token' => $logouttoken,
         );
+
+        // Check if token parameter is required (it is since MediaWiki v1.34)
+        if ($this->supportsModuleParam('logout', 'token')) {
+            // Obtain logout token
+            if (($logouttoken = $this->token()) === null) {
+                return false;
+            }
+            $details['token'] = $logouttoken;
+        }
 
         // Send the logout request
         $logoutResult = $this->request($details, array(), true);

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -153,6 +153,14 @@ class Wikimate
     private $csrfToken = null;
 
     /**
+     * Stored parameter lists for API modules
+     *
+     * @var array
+     * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Parameter_information
+     */
+    private $moduleParams = array();
+
+    /**
      * Creates a new Wikimate object.
      *
      * @param   string    $api      Base URL for the API
@@ -347,6 +355,58 @@ class Wikimate
     }
 
     /**
+     * Obtains parameter lists for API modules.
+     * For specific API modules where supported parameters vary with
+     * MediaWiki versions, this method is used to fetch and store
+     * these parameter lists for use by the API calls of those modules.
+     * Current list of modules for which this mechanism is employed:
+     * - {@link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Logout logout}
+     *
+     * @return void
+     * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Parameter_information
+     */
+    private function storeModuleParams()
+    {
+        // Obtain parameter info for modules
+        $details = array(
+            'action' => 'paraminfo',
+            'modules' => 'logout',
+        );
+
+        // Send the paraminfo request
+        $paramResult = $this->request($details);
+
+        // Check for errors
+        if (isset($paramResult['error'])) {
+            $this->error = $paramResult['error']; // Set the error if there was one
+            return;
+        } else {
+            $this->error = null; // Reset the error status
+        }
+
+        // Store supported parameters for all requested modules
+        foreach ($paramResult['paraminfo']['modules'] as $module) {
+            $this->moduleParams[$module['name']] = array();
+            foreach ($module['parameters'] as $param) {
+                $this->moduleParams[$module['name']][] = $param['name'];
+            }
+        }
+    }
+
+    /**
+     * Checks API module's parameters for a supported parameter.
+     *
+     * @param   string   $module  The module name
+     * @param   string   $param   The parameter name
+     * @return  boolean           True if supported
+     * @link https://www.mediawiki.org/wiki/Special:MyLanguage/API:Parameter_information
+     */
+    public function supportsModuleParam($module, $param)
+    {
+        return in_array($param, $this->moduleParams[$module]);
+    }
+
+    /**
      * Logs in to the wiki.
      *
      * @param   string   $username  The user name
@@ -398,6 +458,9 @@ class Wikimate
             }
             return false;
         }
+
+        // Obtain parameter lists for API modules
+        $this->storeModuleParams();
 
         return true;
     }


### PR DESCRIPTION
Many API modules accept new parameters (or deprecate old ones) as of specific MediaWiki versions. The [paraminfo action](https://www.mediawiki.org/wiki/API:Parameter_information) allows to obtain the list of supported parameters of one or more modules in the MediaWiki instance that Wikimate is used with.

This PR adds an internal mechanism to obtain/store/use supported parameters with the API calls used by Wikimate. It is initially used in `Wikimate::logout()` so that this no longer encounters a warning before MW v1.34.