### PR TITLE
Fix markdownlint execution in the CI pipeline

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,17 +1,22 @@
 name: "Pull Request Checks"
 on: pull_request
 jobs:
-  # Enforce the update of the changelog file
+  # Ensure that the changelog file has been updated in this PR
   check-changelog-change:
     runs-on: ubuntu-latest
     steps:
     - uses: dangoslen/changelog-enforcer@v3
-  # Ensure markdown files are formatted consistently
+  # Ensure that markdown files are formatted consistently (according to .markdownlint.yml)
   lint-markdown-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: xt0rted/markdownlint-problem-matcher@v2
-      - run: npm install -g markdownlint-cli
-      - run: npx --silent glob '**/*.md'
-      - run: markdownlint '**/*.md'
+      - name: Fetch the Wikimate code into the Actions runner
+        uses: actions/checkout@v3
+      - name: Install the markdownlint-problem-matcher action
+        uses: xt0rted/markdownlint-problem-matcher@v2
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli
+      - name: List files that will be processed
+        run: npx --silent glob '**/*.md'
+      - name: Run markdownlint
+        run: markdownlint '**/*.md'

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: xt0rted/markdownlint-problem-matcher@v2
       - run: npm install -g markdownlint-cli
-      - run: markdownlint **/*.md
+      - run: markdownlint '**/*.md'

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -13,4 +13,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: xt0rted/markdownlint-problem-matcher@v2
       - run: npm install -g markdownlint-cli
+      - run: npx --silent glob '**/*.md'
       - run: markdownlint '**/*.md'

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -27,3 +27,8 @@ MD024:
 MD026:
   # Trailing punctuation characters not allowed in headings
   punctuation: ",;:!"
+
+# MD052/reference-links-images
+MD052:
+  # Validate shortcut-style links
+  shortcut_syntax: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 - Clarified instructions in `GOVERNANCE.md` for releasing new versions ([#157])
 - Updated versions of GitHub Actions dependencies ([#161])
+- Fixed markdownlint execution in the CI pipeline ([#154])
 
 <!-- Reference link URLs for this release section -->
+[#154]: https://github.com/hamstar/Wikimate/pull/154
 [#157]: https://github.com/hamstar/Wikimate/pull/157
 [#161]: https://github.com/hamstar/Wikimate/pull/161
 


### PR DESCRIPTION
Follow up from the [conversation from #153](https://github.com/hamstar/Wikimate/pull/153#issuecomment-1644389364).

The advanced glob expression we were using needs to be quoted, as explained in <https://github.com/igorshubovych/markdownlint-cli#globbing>:

> `markdownlint-cli` supports advanced globbing patterns like `**/*.md`. With shells like Bash, it may be necessary to quote globs so they are not interpreted by the shell.