### PR TITLE
Prepare for v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and [Keep a Changelog](http://keepachangelog.com/).
 
 ## Upcoming version
 
+No changes yet.
+
+## Version 1.1.0 - 2023-07-30
+
 ### Added
 
 - Added internal mechanism to handle version-dependent parameters of API modules ([#151])

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It currently consists of three classes:
 - **WikiFile** – Provides an interface to downloading/uploading files and getting their properties.
 
 The [latest released version](https://github.com/hamstar/Wikimate/releases) of Wikimate
-is v1.0.0, released on September 5, 2021.
+is v1.1.0, released on July 30, 2023.
 It requires PHP v5.3 or newer and MediaWiki v1.27 or newer.
 See [CHANGELOG.md](CHANGELOG.md) for the detailed version history.
 
@@ -45,7 +45,7 @@ by adding the following to your existing `composer.json` file:
 ```json
 {
     "require": {
-        "hamstar/Wikimate": "^1.0"
+        "hamstar/Wikimate": "^1.1"
     }
 }
 ```

--- a/Wikimate.php
+++ b/Wikimate.php
@@ -4,7 +4,7 @@
  * Wikimate is a wrapper for the MediaWiki API that aims to be very easy to use.
  *
  * @package    Wikimate
- * @version    1.0.0
+ * @version    1.1.0
  * @copyright  SPDX-License-Identifier: MIT
  */
 
@@ -26,7 +26,7 @@ class Wikimate
      * @var string
      * @link https://semver.org/
      */
-    const VERSION = '1.0.0';
+    const VERSION = '1.1.0';
 
     /**
      * Identifier for CSRF token


### PR DESCRIPTION
Release summary:

This release adds a new undelete method, supports the API's deletetalk parameter in the delete methods based on a new mechanism to handle version-dependent parameters of API modules, updates the dependency on rmccue/requests to v2.x, resolves several warnings, and improves code formatting and commenting. For more details on these changes, including links to the corresponding pull requests, please check the [Changelog](https://github.com/Xymph/Wikimate/blob/master/CHANGELOG.md#version-110---2023-07-23).
