### PR TITLE
Update versions of GitHub Actions dependencies

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -5,13 +5,12 @@ jobs:
   check-changelog-change:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v2
+    - uses: dangoslen/changelog-enforcer@v3
   # Ensure markdown files are formatted consistently
   lint-markdown-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: xt0rted/markdownlint-problem-matcher@v1
+      - uses: actions/checkout@v3
+      - uses: xt0rted/markdownlint-problem-matcher@v2
       - run: npm install -g markdownlint-cli
       - run: markdownlint **/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 - Clarified instructions in `GOVERNANCE.md` for releasing new versions ([#157])
+- Updated versions of GitHub Actions dependencies ([#161])
 
 ## Version 1.1.0 - 2023-07-30
 
@@ -260,3 +261,4 @@ and may require changes in applications that invoke these methods:_
 [#153]: https://github.com/hamstar/Wikimate/pull/153
 [#155]: https://github.com/hamstar/Wikimate/pull/155
 [#157]: https://github.com/hamstar/Wikimate/pull/157
+[#161]: https://github.com/hamstar/Wikimate/pull/161


### PR DESCRIPTION
We are currently getting warnings in GitHub Actions runs ([example](https://github.com/hamstar/Wikimate/actions/runs/5712761765)), saying that the versions of the actions we are using (specifically, `actions/checkout@v2`, `dangoslen/changelog-enforcer@v2` and `xt0rted/markdownlint-problem-matcher@v1`) rely on Node.js 12, which is no [longer going to be supported in GitHub Actions](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/).

Since those actions have had more recent releases since we set them up, this PR updates to those latest versions, which fixes the aforementioned problem.

In addition to the Node.js version bump that these updates bring, there's an additional simplification in the `dangoslen/changelog-enforcer` action, which no longer needs the `checkout` action to be explicitly used beforehand. :smiley: