### PR TITLE
Move reference link URLs in CHANGELOG.md to their sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and [Keep a Changelog](http://keepachangelog.com/).
 - Clarified instructions in `GOVERNANCE.md` for releasing new versions ([#157])
 - Updated versions of GitHub Actions dependencies ([#161])
 
+<!-- Reference link URLs for this release section -->
+[#157]: https://github.com/hamstar/Wikimate/pull/157
+[#161]: https://github.com/hamstar/Wikimate/pull/161
+
 ## Version 1.1.0 - 2023-07-30
 
 ### Added
@@ -36,6 +40,20 @@ and [Keep a Changelog](http://keepachangelog.com/).
   before MediaWiki v1.34 ([#151])
 - Improved various code comments ([#149])
 - Improved more PHPDoc comments ([#150])
+
+<!-- Reference link URLs for this release section -->
+[#142]: https://github.com/hamstar/Wikimate/pull/142
+[#143]: https://github.com/hamstar/Wikimate/pull/143
+[#145]: https://github.com/hamstar/Wikimate/pull/145
+[#146]: https://github.com/hamstar/Wikimate/pull/146
+[#147]: https://github.com/hamstar/Wikimate/pull/147
+[#148]: https://github.com/hamstar/Wikimate/pull/148
+[#149]: https://github.com/hamstar/Wikimate/pull/149
+[#150]: https://github.com/hamstar/Wikimate/pull/150
+[#151]: https://github.com/hamstar/Wikimate/pull/151
+[#152]: https://github.com/hamstar/Wikimate/pull/152
+[#153]: https://github.com/hamstar/Wikimate/pull/153
+[#155]: https://github.com/hamstar/Wikimate/pull/155
 
 ## Version 1.0.0 - 2021-09-05
 
@@ -71,6 +89,21 @@ and may require changes in applications that invoke these methods:_
 - Method `Wikimate::debugCurlConfig()`, deprecated since v0.10.0 ([#128])
 - File `globals.php`, replaced by expanded Composer instructions ([#140])
 
+<!-- Reference link URLs for this release section -->
+[#127]: https://github.com/hamstar/Wikimate/pull/127
+[#128]: https://github.com/hamstar/Wikimate/pull/128
+[#129]: https://github.com/hamstar/Wikimate/pull/129
+[#130]: https://github.com/hamstar/Wikimate/pull/130
+[#131]: https://github.com/hamstar/Wikimate/pull/131
+[#132]: https://github.com/hamstar/Wikimate/pull/132
+[#133]: https://github.com/hamstar/Wikimate/pull/133
+[#134]: https://github.com/hamstar/Wikimate/pull/134
+[#135]: https://github.com/hamstar/Wikimate/pull/135
+[#136]: https://github.com/hamstar/Wikimate/pull/136
+[#138]: https://github.com/hamstar/Wikimate/pull/138
+[#139]: https://github.com/hamstar/Wikimate/pull/139
+[#140]: https://github.com/hamstar/Wikimate/pull/140
+
 ## Version 0.15.0 - 2021-08-26
 
 ### Added
@@ -86,6 +119,13 @@ and may require changes in applications that invoke these methods:_
 ### Fixed
 
 - Fixed format of user agent string ([#121])
+
+<!-- Reference link URLs for this release section -->
+[#121]: https://github.com/hamstar/Wikimate/pull/121
+[#122]: https://github.com/hamstar/Wikimate/pull/122
+[#123]: https://github.com/hamstar/Wikimate/pull/123
+[#124]: https://github.com/hamstar/Wikimate/pull/124
+[#125]: https://github.com/hamstar/Wikimate/pull/125
 
 ## Version 0.14.0 - 2021-08-24
 
@@ -105,6 +145,15 @@ and may require changes in applications that invoke these methods:_
 - Removed null returns from destructors & fixed PHPDoc comments ([#114])
 - Fixed sections object initialization warning in PHP 7.4+ ([#118])
 
+<!-- Reference link URLs for this release section -->
+[#107]: https://github.com/hamstar/Wikimate/pull/107
+[#108]: https://github.com/hamstar/Wikimate/pull/108
+[#109]: https://github.com/hamstar/Wikimate/pull/109
+[#111]: https://github.com/hamstar/Wikimate/pull/111
+[#112]: https://github.com/hamstar/Wikimate/pull/112
+[#114]: https://github.com/hamstar/Wikimate/pull/114
+[#118]: https://github.com/hamstar/Wikimate/pull/118
+
 ## Version 0.13.0 - 2021-07-05
 
 ### Added
@@ -123,6 +172,14 @@ and may require changes in applications that invoke these methods:_
 - Prevented PHP notice in `WikiFile::getInfo()` for moved or deleted file ([#85])
 - Fixed capitalization of a built-in PHP class in a comment ([#106])
 
+<!-- Reference link URLs for this release section -->
+[#83]: https://github.com/hamstar/Wikimate/pull/83
+[#85]: https://github.com/hamstar/Wikimate/pull/85
+[#100]: https://github.com/hamstar/Wikimate/pull/100
+[#101]: https://github.com/hamstar/Wikimate/pull/101
+[#105]: https://github.com/hamstar/Wikimate/pull/105
+[#106]: https://github.com/hamstar/Wikimate/pull/106
+
 ## Version 0.12.0 - 2017-02-03
 
 ### Added
@@ -132,6 +189,13 @@ and may require changes in applications that invoke these methods:_
   ([#69], [#71], [#78], [#80])
 - WikiFile also provides the file history
   and the ability to delete a file or an older revision of it ([#76])
+
+<!-- Reference link URLs for this release section -->
+[#69]: https://github.com/hamstar/Wikimate/pull/69
+[#71]: https://github.com/hamstar/Wikimate/pull/71
+[#76]: https://github.com/hamstar/Wikimate/pull/76
+[#78]: https://github.com/hamstar/Wikimate/pull/78
+[#80]: https://github.com/hamstar/Wikimate/pull/80
 
 ## Version 0.11.0 - 2016-11-16
 
@@ -162,11 +226,35 @@ and may require changes in applications that invoke these methods:_
 - Fixed passing the return value in `WikiPage::setSection()` ([#30])
 - Corrected call to `Wikimate::debugRequestsConfig()` ([#30])
 
+<!-- Reference link URLs for this release section -->
+[#28]: https://github.com/hamstar/Wikimate/pull/28
+[#30]: https://github.com/hamstar/Wikimate/pull/30
+[#32]: https://github.com/hamstar/Wikimate/pull/32
+[#33]: https://github.com/hamstar/Wikimate/pull/33
+[#34]: https://github.com/hamstar/Wikimate/pull/34
+[#37]: https://github.com/hamstar/Wikimate/pull/37
+[#41]: https://github.com/hamstar/Wikimate/pull/41
+[#43]: https://github.com/hamstar/Wikimate/pull/43
+[#45]: https://github.com/hamstar/Wikimate/pull/45
+[#47]: https://github.com/hamstar/Wikimate/pull/47
+[#49]: https://github.com/hamstar/Wikimate/pull/49
+[#50]: https://github.com/hamstar/Wikimate/pull/50
+[#52]: https://github.com/hamstar/Wikimate/pull/52
+[#55]: https://github.com/hamstar/Wikimate/pull/55
+[#57]: https://github.com/hamstar/Wikimate/pull/57
+[#61]: https://github.com/hamstar/Wikimate/pull/61
+[#63]: https://github.com/hamstar/Wikimate/pull/63
+[#64]: https://github.com/hamstar/Wikimate/pull/64
+[#67]: https://github.com/hamstar/Wikimate/pull/67
+
 ## Version 0.10.0 - 2014-06-24
 
 ### Changed
 
 - Switched to using the _Requests_ library instead of Curl ([#25])
+
+<!-- Reference link URLs for this release section -->
+[#25]: https://github.com/hamstar/Wikimate/pull/25
 
 ## Version 0.9 - 2014-06-13
 
@@ -191,74 +279,3 @@ and may require changes in applications that invoke these methods:_
 ## Version 0.3 - 2010-12-26
 
 - Initial commit
-
-[#25]: https://github.com/hamstar/Wikimate/pull/25
-[#28]: https://github.com/hamstar/Wikimate/pull/28
-[#30]: https://github.com/hamstar/Wikimate/pull/30
-[#32]: https://github.com/hamstar/Wikimate/pull/32
-[#33]: https://github.com/hamstar/Wikimate/pull/33
-[#34]: https://github.com/hamstar/Wikimate/pull/34
-[#37]: https://github.com/hamstar/Wikimate/pull/37
-[#41]: https://github.com/hamstar/Wikimate/pull/41
-[#43]: https://github.com/hamstar/Wikimate/pull/43
-[#45]: https://github.com/hamstar/Wikimate/pull/45
-[#47]: https://github.com/hamstar/Wikimate/pull/47
-[#49]: https://github.com/hamstar/Wikimate/pull/49
-[#50]: https://github.com/hamstar/Wikimate/pull/50
-[#52]: https://github.com/hamstar/Wikimate/pull/52
-[#55]: https://github.com/hamstar/Wikimate/pull/55
-[#57]: https://github.com/hamstar/Wikimate/pull/57
-[#61]: https://github.com/hamstar/Wikimate/pull/61
-[#63]: https://github.com/hamstar/Wikimate/pull/63
-[#64]: https://github.com/hamstar/Wikimate/pull/64
-[#67]: https://github.com/hamstar/Wikimate/pull/67
-[#69]: https://github.com/hamstar/Wikimate/pull/69
-[#71]: https://github.com/hamstar/Wikimate/pull/71
-[#76]: https://github.com/hamstar/Wikimate/pull/76
-[#78]: https://github.com/hamstar/Wikimate/pull/78
-[#80]: https://github.com/hamstar/Wikimate/pull/80
-[#83]: https://github.com/hamstar/Wikimate/pull/83
-[#85]: https://github.com/hamstar/Wikimate/pull/85
-[#100]: https://github.com/hamstar/Wikimate/pull/100
-[#101]: https://github.com/hamstar/Wikimate/pull/101
-[#105]: https://github.com/hamstar/Wikimate/pull/105
-[#106]: https://github.com/hamstar/Wikimate/pull/106
-[#107]: https://github.com/hamstar/Wikimate/pull/107
-[#108]: https://github.com/hamstar/Wikimate/pull/108
-[#109]: https://github.com/hamstar/Wikimate/pull/109
-[#111]: https://github.com/hamstar/Wikimate/pull/111
-[#112]: https://github.com/hamstar/Wikimate/pull/112
-[#114]: https://github.com/hamstar/Wikimate/pull/114
-[#118]: https://github.com/hamstar/Wikimate/pull/118
-[#121]: https://github.com/hamstar/Wikimate/pull/121
-[#122]: https://github.com/hamstar/Wikimate/pull/122
-[#123]: https://github.com/hamstar/Wikimate/pull/123
-[#124]: https://github.com/hamstar/Wikimate/pull/124
-[#125]: https://github.com/hamstar/Wikimate/pull/125
-[#127]: https://github.com/hamstar/Wikimate/pull/127
-[#128]: https://github.com/hamstar/Wikimate/pull/128
-[#129]: https://github.com/hamstar/Wikimate/pull/129
-[#130]: https://github.com/hamstar/Wikimate/pull/130
-[#131]: https://github.com/hamstar/Wikimate/pull/131
-[#132]: https://github.com/hamstar/Wikimate/pull/132
-[#133]: https://github.com/hamstar/Wikimate/pull/133
-[#134]: https://github.com/hamstar/Wikimate/pull/134
-[#135]: https://github.com/hamstar/Wikimate/pull/135
-[#136]: https://github.com/hamstar/Wikimate/pull/136
-[#138]: https://github.com/hamstar/Wikimate/pull/138
-[#139]: https://github.com/hamstar/Wikimate/pull/139
-[#140]: https://github.com/hamstar/Wikimate/pull/140
-[#142]: https://github.com/hamstar/Wikimate/pull/142
-[#143]: https://github.com/hamstar/Wikimate/pull/143
-[#145]: https://github.com/hamstar/Wikimate/pull/145
-[#146]: https://github.com/hamstar/Wikimate/pull/146
-[#147]: https://github.com/hamstar/Wikimate/pull/147
-[#148]: https://github.com/hamstar/Wikimate/pull/148
-[#149]: https://github.com/hamstar/Wikimate/pull/149
-[#150]: https://github.com/hamstar/Wikimate/pull/150
-[#151]: https://github.com/hamstar/Wikimate/pull/151
-[#152]: https://github.com/hamstar/Wikimate/pull/152
-[#153]: https://github.com/hamstar/Wikimate/pull/153
-[#155]: https://github.com/hamstar/Wikimate/pull/155
-[#157]: https://github.com/hamstar/Wikimate/pull/157
-[#161]: https://github.com/hamstar/Wikimate/pull/161


### PR DESCRIPTION
Just an experimental change that may make this file easier to edit (and to consume, in source mode).
