### PR TITLE
Update API URLs to typical path, update other links, and use https

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -21,7 +21,7 @@ MD013:
 # MD024/no-duplicate-heading
 MD024:
   # Only check sibling headings
-  allow_different_nesting: true
+  siblings_only: true
 
 # MD026/no-trailing-punctuation
 MD026:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 This page lists the changes that were done in each version of Wikimate.
 
-Since v0.10.0 this project adheres to [Semantic Versioning](http://semver.org/)
-and [Keep a Changelog](http://keepachangelog.com/).
+Since v0.10.0 this project adheres to [Semantic Versioning](https://semver.org/)
+and [Keep a Changelog](https://keepachangelog.com/).
 
 ## Upcoming version
 
 ### Changed
 
 - Clarified instructions in `GOVERNANCE.md` for releasing new versions ([#157])
+- Updated API URLs to typical path, updated other links, and use https ([#163])
 - Updated versions of GitHub Actions dependencies ([#161])
 - Fixed markdownlint execution in the CI pipeline ([#154])
 
@@ -17,6 +18,7 @@ and [Keep a Changelog](http://keepachangelog.com/).
 [#154]: https://github.com/hamstar/Wikimate/pull/154
 [#157]: https://github.com/hamstar/Wikimate/pull/157
 [#161]: https://github.com/hamstar/Wikimate/pull/161
+[#163]: https://github.com/hamstar/Wikimate/pull/163
 
 ## Version 1.1.0 - 2023-07-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ no matter how small!
 Feel free to open [an issue](https://github.com/hamstar/Wikimate/issues/new)
 to discuss your suggestion or request,
 or submit your changes directly as a
-[pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
+[pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
 if you prefer.
 
 Below are some guidelines that might help you prepare your contribution.
@@ -18,7 +18,7 @@ Below are some guidelines that might help you prepare your contribution.
    Try to create commits that are as small as possible
    while still representing a self-contained set of changes,
    and use descriptive commit messages.
-   We recommend [these principles](https://chris.beams.io/posts/git-commit/#seven-rules)
+   We recommend [these principles](https://cbea.ms/git-commit/#seven-rules)
    for writing great commit messages (but they're not enforced, so don't sweat it 🙂).
 3. **Include a `CHANGELOG.md` entry in every pull request**.
    This makes it much easier to prepare releases,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -41,7 +41,7 @@ It should apply the following actions:
 
 1. Change the "Upcoming version" heading in the `CHANGELOG.md` file
    to the appropriate version number and date (e.g. `Version 1.2.3 - 2020-12-31`).
-   Follow the [SemVer](http://semver.org/) conventions
+   Follow the [SemVer](https://semver.org/) conventions
    to determine which part of the version number to increase.
 2. Still in the `CHANGELOG.md` file,
    add a new "Upcoming version" section heading above the other sections,

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ to log in to that wiki.
 ```php
 require __DIR__.'/vendor/autoload.php';
 
-$api_url = 'http://example.com/api.php';
+$api_url = 'https://example.com/w/api.php';
 $username = 'bot';
 $password = 'password';
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -28,7 +28,7 @@ to log in to that wiki.
 ```php
 require __DIR__.'/vendor/autoload.php';
 
-$api_url = 'http://example.com/api.php';
+$api_url = 'https://example.com/w/api.php';
 $username = 'bot';
 $password = 'password';
 

--- a/examples.php
+++ b/examples.php
@@ -2,7 +2,7 @@
 
 include 'globals.php';
 
-$api_url = 'http://localhost/mediawiki/api.php';
+$api_url = 'https://localhost/mediawiki/w/api.php';
 echo "Connecting to: $api_url\n";
 
 echo "Enter your username: ";


### PR DESCRIPTION
I noticed a few http links now redirect to https, and an extended URL scan pointed to some other links also worth updating.